### PR TITLE
Handle offline Vintage Story server gracefully

### DIFF
--- a/modules/VintageStoryStatus.ts
+++ b/modules/VintageStoryStatus.ts
@@ -32,7 +32,19 @@ module.exports = function (client: FpgClient) {
           (s) => s.serverName === process.env.VS_SERVER_NAME
         );
         if (!server) {
-          throw new Error(`No server found for ${process.env.VS_SERVER_NAME}`);
+          log.warn(`No server found for ${process.env.VS_SERVER_NAME} — server may be offline`);
+          global.client.user.setActivity("flamingpalm.com", {
+            type: ActivityType.Watching,
+          });
+          client.channels
+            .fetch(VS_CHANNEL_ID)
+            .then((channel) => {
+              (channel as BaseGuildTextChannel).setName("🏕️┃vintage-story");
+            })
+            .catch((error) =>
+              log.error("Failed to reset VS channel name:", error)
+            );
+          return;
         }
         global.client.user.setActivity(
           "VintageStory " + server.players + "/8",


### PR DESCRIPTION
## Summary
Modified the Vintage Story status module to handle cases where the configured server is offline, instead of throwing an error and crashing.

## Key Changes
- Changed error handling from throwing an exception to logging a warning when the server is not found
- Set bot activity to "Watching flamingpalm.com" when server is offline
- Reset the Vintage Story channel name to "🏕️┃vintage-story" when server is offline
- Added error handling for channel name reset operations

## Implementation Details
When the configured Vintage Story server is unavailable:
- A warning is logged indicating the server may be offline
- The bot's Discord status is updated to show a generic activity instead of player count
- The VS channel name is reset to its default state
- The function returns early without throwing an error, allowing the bot to continue operating normally

https://claude.ai/code/session_01CLJ6fGRNHAjRPr7VHxZYFQ