### PR TITLE
Add Islander — Discord-native island-building game (Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,14 @@ FlamingPalmKrakenV2/
 ├── interfaces/
 │   ├── IHandler.ts           # Interface for all interaction handlers
 │   └── IEvent.ts             # Interface for all event handlers
-├── islander/
-│   └── ChannelUpdates.ts     # Island game mechanics module
+├── islander/                 # "Islander" island-building game (see docs/ISLANDER_DESIGN.md)
+│   ├── IslanderModule.ts     # Core: island lifecycle + lazy resource accrual
+│   ├── IslanderSeed.ts       # Seeds i_Building/i_BuildingLevel/i_Unit from balance data
+│   ├── IslanderView.ts       # Builds the /island message payload (embed+image+buttons)
+│   ├── IslanderImage.ts      # @napi-rs/canvas island renderer
+│   ├── IslanderEmbeds.ts     # Island status embeds
+│   ├── ChannelUpdates.ts     # Generic update-channel helper (profile/raid messages)
+│   └── data/balance.ts       # Game balance constants (mirrors docs/ISLANDER_BALANCE.md)
 ├── utils/
 │   └── logger.ts             # Color-coded logger with Bugsnag integration
 ├── assets/                   # Images and badge files for profile generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,17 @@ const raids = await global.client.prisma.raids.findMany(...);
 ### Scripts
 ```bash
 npm run build    # Compile TypeScript → ./bin/
-npm start        # Run compiled bot (./bin/index.js)
+npm start        # Apply pending DB migrations (prisma migrate deploy) + run the bot
+npm run migrate  # Apply pending DB migrations only (prisma migrate deploy)
 npm run deploy   # Build + register slash commands with Discord
 ```
+
+> **Note:** `npm start` runs `prisma migrate deploy` before launching the bot, so
+> pending migrations are applied on every (re)start — including CapRover deploys,
+> whose `CMD` is `npm start`. `migrate deploy` is idempotent and needs no shadow
+> DB. If the DB predates Prisma's migration history, baseline it once with
+> `npx prisma migrate resolve --applied <migration_name>` so `deploy` doesn't try
+> to re-run already-applied migrations.
 
 > **Note:** There is no test suite — tests were removed in a previous refactor. `tsconfig.test.json` is a leftover artifact.
 
@@ -168,10 +176,13 @@ Always run `npx prisma generate` after editing `prisma/schema.prisma`.
 
 ### Deployment
 The project deploys via **CapRover** using the `captain-definition` file. The Docker image:
-1. Uses `node:21-alpine`
+1. Uses `node:24-alpine`
 2. Installs Manrope fonts
-3. Compiles TypeScript
-4. Exposes port 80 for the Express web API
+3. Runs `npx prisma generate`
+4. Compiles TypeScript
+5. Exposes port 80 for the Express web API
+6. Starts with `npm start`, which runs `prisma migrate deploy` (applying any
+   pending DB migrations against `DATABASE_URL`) before launching the bot
 
 ---
 

--- a/docs/ISLANDER_BALANCE.md
+++ b/docs/ISLANDER_BALANCE.md
@@ -75,35 +75,35 @@ Each line below lists Tier-1 base stats; higher tiers use the growth curve and
 the named tier swaps in at the level shown. `Function` / `FunctAttribute` columns
 show what the building's data row drives.
 
-### 3.1 Food — Farm → Farm Estate → (TBD)
+### 3.1 Food — Farm → Farm Estate → Plantation
 | Level | Name | Wood | Stone | Food/h | Time | TC req |
 |---|---|---|---|---|---|---|
 | 1 | Farm | 50 | 30 | 60 | 30 | 1 |
 | 5 | Farm | 470 | 280 | 200 | 760 | 5 |
 | 10 | Farm Estate | 4.3k | 2.6k | 900 | 21.6k | 10 |
-| 20 | Farm Estate | 80k | 48k | 12.5k | 86.4k | 20 |
+| 20 | Plantation | 80k | 48k | 12.5k | 86.4k | 20 |
 
 `Function = produce`, `FunctAttribute = Food/h`.
 
-### 3.2 Wood — Woodcutter → Logging Camp → (TBD)
+### 3.2 Wood — Woodcutter → Logging Camp → Sawmill
 | Level | Name | Wood | Stone | Wood/h | Time | TC req |
 |---|---|---|---|---|---|---|
 | 1 | Woodcutter | 40 | 20 | 55 | 30 | 1 |
 | 5 | Woodcutter | 370 | 185 | 185 | 760 | 5 |
 | 10 | Logging Camp | 3.5k | 1.7k | 830 | 21.6k | 10 |
-| 20 | Logging Camp | 65k | 32k | 11.5k | 86.4k | 20 |
+| 20 | Sawmill | 65k | 32k | 11.5k | 86.4k | 20 |
 
-### 3.3 Stone — Mine → Quarry → (TBD)
+### 3.3 Stone — Mine → Quarry → Stoneworks
 Same base as Wood (Mine produces Stone/h). Stone is slightly scarcer in demand
 (walls/repairs), so keep rates equal to Wood and let wall costs create the
 tension.
 
-### 3.4 Currency — Trader → Marketplace → (TBD)
+### 3.4 Currency — Trader → Marketplace → Grand Bazaar
 | Level | Name | Wood | Stone | Currency/h | Time | TC req |
 |---|---|---|---|---|---|---|
 | 1 | Trader | 120 | 100 | 20 | 600 | 8 |
 | 10 | Marketplace | 6k | 5k | 220 | 21.6k | 10 |
-| 20 | Marketplace | 95k | 80k | 2.8k | 86.4k | 20 |
+| 20 | Grand Bazaar | 95k | 80k | 2.8k | 86.4k | 20 |
 
 Currency is intentionally the **slowest** resource and the main raiding reward —
 this is the answer to the brainstorm's "not sure how currency is generated."
@@ -113,15 +113,15 @@ Marketplace also enables a **resource exchange** (see §7).
 
 ## 4. Storage & Housing
 
-### 4.1 Warehouse (storage cap)
+### 4.1 Warehouse — Warehouse → Storehouse → Grand Depot (storage cap)
 `Function = store`, `FunctAttribute = capacity added per resource`.
 
 | Level | Name | Wood | Stone | +Storage (all resources) | Time | TC req |
 |---|---|---|---|---|---|---|
 | 1 | Warehouse | 60 | 40 | +1,000 | 60 | 1 |
 | 5 | Warehouse | 560 | 370 | +5,500 | 1k | 5 |
-| 10 | Warehouse | 5k | 3.4k | +28k | 21.6k | 10 |
-| 20 | Warehouse | 95k | 64k | +400k | 86.4k | 20 |
+| 10 | Storehouse | 5k | 3.4k | +28k | 21.6k | 10 |
+| 20 | Grand Depot | 95k | 64k | +400k | 86.4k | 20 |
 
 **Total cap** = `BASE_STORAGE + 250·TClevel + Warehouse capacity`.
 **Idle window** = `cap / ratePerHour` — early game ≈ 8–12 h, late game tuned to
@@ -153,7 +153,7 @@ Caps total land units = `30 · level`. `Function = train`.
 | 10 | Barracks | 6k | 4k | 4.5k | 300 | 21.6k | 15 |
 | 20 | Army Base | 95k | 64k | 70k | 600 | 86.4k | 20 |
 
-### 5.2 Smithing — Smelter → Blacksmith → (TBD)
+### 5.2 Smithing — Smelter → Blacksmith → Foundry
 `Function = defend/attack multiplier`. Each level adds **+3% army attack & HP**
 (applies to both raiding and defending).
 
@@ -161,7 +161,7 @@ Caps total land units = `30 · level`. `Function = train`.
 |---|---|---|---|---|---|---|
 | 1 | Smelter | 150 | 200 | +3% | 600 | 5 |
 | 10 | Blacksmith | 5k | 7k | +30% | 21.6k | 15 |
-| 20 | Blacksmith | 80k | 110k | +60% | 86.4k | 20 |
+| 20 | Foundry | 80k | 110k | +60% | 86.4k | 20 |
 
 ### 5.3 Naval — Dock → Harbour → Port
 Builds ships (naval units) and **unlocks/extends raid range**. v1: Dock level ≥ 1
@@ -200,14 +200,16 @@ Damage reduction is capped at **45%** so walls never make an island unbeatable.
 
 Pre-battle kill is capped at **25%**.
 
-### 6.3 Castle/Keep — the Vault
+### 6.3 Keep line — Castle → Keep → Citadel (the Vault)
 `Function = vault`, `FunctAttribute = % of each resource protected from raids`.
+Late-unlock line (Castle requires a high TC).
 
 | Level | Name | Wood | Stone | Vault % protected | Vault flat floor | Time | TC req |
-|---|---|---|---|---|---|---|
+|---|---|---|---|---|---|---|---|
 | 1 | Castle | 2k | 3k | 15% | 1,000 | 7.2k | 15 |
 | 5 | Castle | 18k | 27k | 25% | 5,000 | 50k | 18 |
 | 10 | Keep | 60k | 90k | 40% | 20,000 | 86.4k | 25 |
+| 15 | Citadel | 160k | 240k | 55% | 50,000 | 86.4k | 30 |
 
 **Protected amount** per resource = `max(flatFloor, total · vault%)`, clamped to
 the current total. Loot can only ever touch the unprotected remainder.

--- a/docs/ISLANDER_BALANCE.md
+++ b/docs/ISLANDER_BALANCE.md
@@ -1,0 +1,313 @@
+# Islander — Balance & Tuning
+
+> **Status:** Draft seed values (v1)
+> **Companion to:** `ISLANDER_DESIGN.md`
+> **Last updated:** 2026-06-04
+
+This document holds the **concrete numbers** for Islander: production rates,
+costs, build times, unit stats, and the PvP levers. It is deliberately separate
+from the design doc so tuning churn doesn't pollute the spec.
+
+**These map directly onto the `i_BuildingLevel`, `i_Unit`, and `i_Island` schema
+in `ISLANDER_DESIGN.md` §9.2.** Everything here lives in **data** (DB rows or a
+seed file), never hard-coded — tuning is a row edit + `/island-reload`.
+
+All times are in **seconds** (matching `i_BuildingLevel.Time`). All resource
+amounts are integers. "h" = per hour.
+
+---
+
+## 1. Global Constants
+
+| Constant | Value | Notes |
+|---|---|---|
+| `BASE_STORAGE` | 500 | Per-resource cap from a level-1 Town Center, before Warehouse. |
+| `TICK_GRANULARITY` | 60 s | Resolution of lazy accrual (gains computed per-minute). |
+| `STARVATION_RATE` | 5 %/h | Population decay per hour when Food = 0. |
+| `RUSH_RATE` | 1 Currency per 6 s | Cost to instant-finish a build (`remainingSeconds / 6`). |
+| `OFFLINE_CAP_HOURS` | derived | = `storageCap / ratePerHour`; the idle window. |
+| `START_WOOD / STONE / FOOD` | 300 each | Starting resources for a fresh island. |
+| `START_CURRENCY` | 50 | |
+| `START_POPULATION` | 5 | Idle pop available to assign. |
+
+### Cost/time growth curve
+Unless a table says otherwise, per-level scaling uses:
+
+```
+cost(level)  = round( base * 1.55^(level-1) )
+time(level)  = round( baseTime * 1.50^(level-1) )   # capped at TIME_CAP
+rate(level)  = round( baseRate * 1.35^(level-1) )
+TIME_CAP     = 86400  # 24h — no single upgrade exceeds a day in v1
+```
+
+`1.55` cost / `1.50` time / `1.35` production is the classic "production grows
+slower than cost" curve that keeps later levels meaningful without infinite idle
+times.
+
+---
+
+## 2. Town Center (level gate)
+
+The TC gates every other building: a building's level may not exceed the TC
+level. Max level v1 = **30**.
+
+| TC Level | Name | Wood | Stone | Food | Time | Unlocks |
+|---|---|---|---|---|---|---|
+| 1 | Campfire | — | — | — | — | Start: Farm, Woodcutter, Mine, Tents, Warehouse |
+| 2 | Campfire | 200 | 150 | 100 | 120 | — |
+| 3 | Campfire | 400 | 300 | 200 | 300 | Army Camp, Palisade Walls |
+| 5 | Town Centre | 1.2k | 1k | 600 | 1.8k | Smelter, Dock, Watch Tower |
+| 8 | Town Centre | 4k | 3.5k | 2k | 7.2k | Trader, Academy |
+| 10 | Town Centre | 9k | 8k | 5k | 21.6k | Tier-2 buildings (Houses, Logging Camp, Quarry…) |
+| 15 | Town Centre | 30k | 28k | 18k | 50k | Castle, Barracks, Harbour, Guard Tower |
+| 20 | Palace | 90k | 85k | 55k | 86.4k | Tier-3 buildings (Villas, Army Base, Port…) |
+| 25 | Palace | 200k | 190k | 120k | 86.4k | Keep, Bombard Tower |
+| 30 | Palace | 450k | 430k | 280k | 86.4k | Max island |
+
+> TC also adds a flat **+250 storage per level** to every resource on top of the
+> Warehouse.
+
+---
+
+## 3. Production Buildings
+
+Each line below lists Tier-1 base stats; higher tiers use the growth curve and
+the named tier swaps in at the level shown. `Function` / `FunctAttribute` columns
+show what the building's data row drives.
+
+### 3.1 Food — Farm → Farm Estate → (TBD)
+| Level | Name | Wood | Stone | Food/h | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Farm | 50 | 30 | 60 | 30 | 1 |
+| 5 | Farm | 470 | 280 | 200 | 760 | 5 |
+| 10 | Farm Estate | 4.3k | 2.6k | 900 | 21.6k | 10 |
+| 20 | Farm Estate | 80k | 48k | 12.5k | 86.4k | 20 |
+
+`Function = produce`, `FunctAttribute = Food/h`.
+
+### 3.2 Wood — Woodcutter → Logging Camp → (TBD)
+| Level | Name | Wood | Stone | Wood/h | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Woodcutter | 40 | 20 | 55 | 30 | 1 |
+| 5 | Woodcutter | 370 | 185 | 185 | 760 | 5 |
+| 10 | Logging Camp | 3.5k | 1.7k | 830 | 21.6k | 10 |
+| 20 | Logging Camp | 65k | 32k | 11.5k | 86.4k | 20 |
+
+### 3.3 Stone — Mine → Quarry → (TBD)
+Same base as Wood (Mine produces Stone/h). Stone is slightly scarcer in demand
+(walls/repairs), so keep rates equal to Wood and let wall costs create the
+tension.
+
+### 3.4 Currency — Trader → Marketplace → (TBD)
+| Level | Name | Wood | Stone | Currency/h | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Trader | 120 | 100 | 20 | 600 | 8 |
+| 10 | Marketplace | 6k | 5k | 220 | 21.6k | 10 |
+| 20 | Marketplace | 95k | 80k | 2.8k | 86.4k | 20 |
+
+Currency is intentionally the **slowest** resource and the main raiding reward —
+this is the answer to the brainstorm's "not sure how currency is generated."
+Marketplace also enables a **resource exchange** (see §7).
+
+---
+
+## 4. Storage & Housing
+
+### 4.1 Warehouse (storage cap)
+`Function = store`, `FunctAttribute = capacity added per resource`.
+
+| Level | Name | Wood | Stone | +Storage (all resources) | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Warehouse | 60 | 40 | +1,000 | 60 | 1 |
+| 5 | Warehouse | 560 | 370 | +5,500 | 1k | 5 |
+| 10 | Warehouse | 5k | 3.4k | +28k | 21.6k | 10 |
+| 20 | Warehouse | 95k | 64k | +400k | 86.4k | 20 |
+
+**Total cap** = `BASE_STORAGE + 250·TClevel + Warehouse capacity`.
+**Idle window** = `cap / ratePerHour` — early game ≈ 8–12 h, late game tuned to
+≈ 12–18 h so a daily check-in never wastes much.
+
+### 4.2 Housing — Tents → Houses → Villas
+`Function = store` (population capacity). Converts Food upkeep into pop ceiling.
+
+| Level | Name | Wood | Stone | Pop Capacity | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Tents | 40 | 20 | 10 | 45 | 1 |
+| 5 | Tents | 370 | 185 | 45 | 1.1k | 5 |
+| 10 | Houses | 3.5k | 1.7k | 160 | 21.6k | 10 |
+| 20 | Villas | 65k | 32k | 1,400 | 86.4k | 20 |
+
+**Population growth:** while `population < popCapacity` and Food > 0, pop grows at
+`max(1, popCapacity * 2%) /h`, consuming **0.5 Food per pop per hour** as upkeep.
+
+---
+
+## 5. Military Buildings
+
+### 5.1 Army — Army Camp → Barracks → Army Base
+Caps total land units = `30 · level`. `Function = train`.
+
+| Level | Name | Wood | Stone | Food | Unit Cap | Time | TC req |
+|---|---|---|---|---|---|---|---|
+| 1 | Army Camp | 200 | 120 | 150 | 30 | 600 | 3 |
+| 10 | Barracks | 6k | 4k | 4.5k | 300 | 21.6k | 15 |
+| 20 | Army Base | 95k | 64k | 70k | 600 | 86.4k | 20 |
+
+### 5.2 Smithing — Smelter → Blacksmith → (TBD)
+`Function = defend/attack multiplier`. Each level adds **+3% army attack & HP**
+(applies to both raiding and defending).
+
+| Level | Name | Wood | Stone | Atk/HP Bonus | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Smelter | 150 | 200 | +3% | 600 | 5 |
+| 10 | Blacksmith | 5k | 7k | +30% | 21.6k | 15 |
+| 20 | Blacksmith | 80k | 110k | +60% | 86.4k | 20 |
+
+### 5.3 Naval — Dock → Harbour → Port
+Builds ships (naval units) and **unlocks/extends raid range**. v1: Dock level ≥ 1
+is required to `/raid` at all (you need boats to reach another island).
+
+| Level | Name | Wood | Stone | Ship Cap | Raid Cooldown reduction | Time | TC req |
+|---|---|---|---|---|---|---|---|
+| 1 | Dock | 250 | 150 | 5 | 0% | 900 | 5 |
+| 10 | Harbour | 7k | 4.5k | 40 | -20% | 21.6k | 15 |
+| 20 | Port | 110k | 70k | 100 | -40% | 86.4k | 20 |
+
+---
+
+## 6. Defensive Buildings
+
+### 6.1 Walls — Palisade → Stone → Reinforced
+`Function = defend`, `FunctAttribute = wallHP`. Wall HP is **damaged in raids**
+and repaired with Stone (§7). While `wallHP > 0`, incoming damage is reduced.
+
+| Level | Name | Wood | Stone | Wall HP | Damage Reduction | Time | TC req |
+|---|---|---|---|---|---|---|---|
+| 1 | Palisade Walls | 100 | 200 | 500 | 5% | 300 | 3 |
+| 10 | Stone Walls | 3k | 6k | 6,000 | 25% | 21.6k | 10 |
+| 20 | Reinforced Walls | 50k | 95k | 80,000 | 45% | 86.4k | 20 |
+
+Damage reduction is capped at **45%** so walls never make an island unbeatable.
+
+### 6.2 Towers — Watch → Guard → Bombard
+`Function = defend`, auto-kills a % of attacking units **before** the clash.
+
+| Level | Name | Wood | Stone | Pre-battle kill % | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Watch Tower | 120 | 150 | 2% | 300 | 5 |
+| 10 | Guard Tower | 4k | 5k | 12% | 21.6k | 15 |
+| 20 | Bombard Tower | 70k | 90k | 25% | 86.4k | 20 |
+
+Pre-battle kill is capped at **25%**.
+
+### 6.3 Castle/Keep — the Vault
+`Function = vault`, `FunctAttribute = % of each resource protected from raids`.
+
+| Level | Name | Wood | Stone | Vault % protected | Vault flat floor | Time | TC req |
+|---|---|---|---|---|---|---|
+| 1 | Castle | 2k | 3k | 15% | 1,000 | 7.2k | 15 |
+| 5 | Castle | 18k | 27k | 25% | 5,000 | 50k | 18 |
+| 10 | Keep | 60k | 90k | 40% | 20,000 | 86.4k | 25 |
+
+**Protected amount** per resource = `max(flatFloor, total · vault%)`, clamped to
+the current total. Loot can only ever touch the unprotected remainder.
+
+---
+
+## 7. Repairs & Resource Exchange
+
+- **Wall repair (`/repair`):** restores wall HP at **1 Stone per 4 HP**. Repairs
+  are instant (no timer) but cost-gated.
+- **Currency rush:** `ceil(remainingSeconds / 6)` Currency to finish a build now.
+- **Marketplace exchange:** trade resources at a **1.5 : 1** ratio (e.g. 150 Wood
+  → 100 Stone), with a per-day volume cap of `Marketplace level · 1,000` per
+  resource to prevent laundering raided loot into Currency too freely.
+
+---
+
+## 8. Units
+
+`Attack`, `HP`, `Loot` map to `i_Unit`. Cost is per unit. Training time is per
+unit (batched, sequential).
+
+| Unit | Type | Wood | Food | Currency | Pop | Attack | HP | Loot | Train (s) | Req |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **Raider** | land | 15 | 20 | 0 | 1 | 8 | 20 | 50 | 60 | Army Camp 1 |
+| **Soldier** | land | 25 | 25 | 0 | 1 | 12 | 45 | 10 | 90 | Army Camp 3 |
+| **Champion** | land | 60 | 50 | 20 | 2 | 35 | 110 | 40 | 240 | Barracks (lvl 10) |
+| **Longboat** | naval | 120 | 30 | 10 | 3 | 25 | 150 | 300 | 300 | Dock 1 |
+| **War Galley** | naval | 300 | 60 | 40 | 5 | 70 | 400 | 800 | 600 | Harbour (lvl 10) |
+
+Design intent:
+- **Raider** = glass-cannon looter (high loot, low HP) → offense.
+- **Soldier** = cheap wall of HP → defense.
+- **Champion** = elite all-rounder, TC/Barracks gated.
+- **Longboats/Galleys** carry the bulk of loot home — without ships, even a won
+  raid carries little back.
+
+Killed units free their `Pop` back into the idle pool over **30 min** (re-train
+later); the unit instances themselves are lost.
+
+---
+
+## 9. PvP Levers (the important knobs)
+
+| Lever | v1 value | Effect |
+|---|---|---|
+| `LOOT_PERCENT` | 20% | Max % of a defender's *unprotected* resources a raid can take. |
+| `NEW_PLAYER_SHIELD_TC` | TC < 5 | Islands below this TC are unraidable. |
+| `POST_RAID_SHIELD` | 8 h | Protection window after being successfully raided. |
+| `RAID_COOLDOWN` | 4 h | Base attacker cooldown (reduced by Naval, §5.3). |
+| `REPEAT_TARGET_COOLDOWN` | 24 h | Can't re-raid the same victim within this window. |
+| `MATCHMAKING_BAND` | ±5 TC | `/raid` target's TC must be within ±5 of attacker's. |
+| `SCOUT_COST` | 50 Currency | Cost of `/scout` for an estimated defense readout. |
+| `WALL_DR_CAP` | 45% | Max wall damage reduction. |
+| `TOWER_KILL_CAP` | 25% | Max pre-battle attacker losses to towers. |
+
+### Combat resolution formula (reference)
+```
+atkPower = Σ(unit.Attack · count) · (1 + smithingBonus)
+defPower = Σ(garrison.HP-weighted defense) · (1 + smithingBonus)
+# 1. towers remove min(TOWER_KILL_CAP, towerKill%) of attackers
+# 2. walls reduce attacker effective power by min(WALL_DR_CAP, wallDR%)
+# 3. ratio = atkPower_eff / (atkPower_eff + defPower)
+# 4. jitter ratio by ±10% (seeded RNG, logged)
+# 5. attackerWins = ratio > 0.5
+# 6. casualties scale with (1 - |ratio - 0.5|·2): closer fights = bloodier
+# 7. if win: loot = min(Σ survivingLootCapacity,
+#                       LOOT_PERCENT · unprotectedResources)
+# 8. wallHP -= damage dealt; defender must /repair
+```
+The `±10%` jitter and casualty-on-both-sides rule mean a slightly weaker attacker
+*can* win but bleeds for it — discouraging risk-free farming.
+
+---
+
+## 10. Power Score (leaderboard & matchmaking)
+
+```
+powerScore = 10·TClevel
+           + 3·Σ(buildingLevels)
+           + 1·Σ(unit.Attack·count + unit.HP·count)/10
+```
+Used by `/island-leaderboard` and as a secondary matchmaking sanity check
+alongside the TC band.
+
+---
+
+## 11. Tuning Methodology
+
+When adjusting these numbers post-launch:
+1. **Change one lever at a time**, observe over ≥1 week of play.
+2. **Idle window** (`cap / rate`) is the master pacing dial — target 12–18 h
+   late game. Adjust Warehouse capacity, not production, to move it.
+3. **PvP health check:** if raids empty victims, lower `LOOT_PERCENT` or raise
+   vault %; if no one raids, lower cooldowns or raise loot.
+4. Keep all changes as **DB row edits** + `/island-reload`. Never inline a
+   constant that belongs in a `*_Level` row.
+5. Record balance changes in this file's changelog below.
+
+### Changelog
+| Date | Change |
+|---|---|
+| 2026-06-04 | Initial v1 seed values. |

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -1,0 +1,441 @@
+# Islander — Game Design Document
+
+> **Status:** Draft / proposed feature
+> **Owner:** FlamingPalm community team
+> **Last updated:** 2026-06-04
+
+Islander is a **Discord-native island-building game** for the FlamingPalm
+community, played through the FlamingPalmKrakenV2 bot. Each member owns a single
+persistent island, gathers resources over time, constructs and upgrades
+buildings, trains an army, and **raids other members' islands** for loot —
+while defending their own with walls, towers and a garrison.
+
+This document is the source of truth for the game's mechanics and its technical
+shape inside this codebase. It supersedes the original brainstorm notes
+(`FPG_discord_island_builder.docx`) and the abandoned `i_*` Prisma models that
+were removed in commit `88417ca`.
+
+---
+
+## 1. Design Goals & Pillars
+
+1. **Idle-friendly.** Resources accumulate over real time so players can "play"
+   in short daily bursts. Warehouses cap how long you can idle before
+   production stalls — a gentle nudge to log back in.
+2. **Build → Power → Raid → Defend loop.** Every system feeds the core loop:
+   gather → build/upgrade → train army → raid rivals → defend & repair.
+3. **Discord-first UX.** No external client. Everything is a slash command, a
+   rendered island image, and a row of buttons.
+4. **Community-flavoured PvP.** Raiding is competitive but bounded by
+   protection windows, cooldowns and loot caps so it never becomes pure
+   bullying or a runaway snowball.
+5. **Self-contained economy (for now).** Islander's resources are **separate**
+   from the community Points/Rewards system. Integration hooks are designed in
+   from day one (see §10) but disabled at launch.
+
+### Non-goals (v1)
+- No real-money or Points spending into the game.
+- No alliances/clans (candidate for a later phase).
+- No live combat animation — combat resolves instantly and is reported as an
+  embed + image.
+
+---
+
+## 2. Core Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Economy | **Self-contained**, Points integration deferred | Protect the existing shop economy; revisit once balanced. |
+| PvP | **Full player-vs-player raiding** | Gives walls/towers/army purpose; drives engagement. |
+| Interface | **Slash commands + generated image + action buttons** | Matches existing bot patterns (profile image tech) and feels modern. |
+| Time model | **Tick-based accrual** (lazy evaluation) | Cheap; no per-second cron. Resources computed on read from `lastTick`. |
+| One island per member | Yes, keyed by Discord user ID | Mirrors the original `i_Island.ID = Members.ID` design. |
+
+---
+
+## 3. Resources
+
+Five core resources (carried over from the brainstorm). Two "maybe" resources
+(Research, Faith) are deferred to a later phase.
+
+| Resource | Symbol | Produced by | Spent on | Raidable? |
+|---|---|---|---|---|
+| **Wood** | 🪵 | Woodcutter line | Boats, buildings, upgrades | Yes |
+| **Stone** | 🪨 | Mine line | Buildings, walls, repairs | Yes |
+| **Food** | 🍖 | Farm line | Population growth & upkeep | Yes |
+| **Currency** | 🪙 | Trade buildings + raiding | Trading, instant-finish, rush upgrades | Yes |
+| **Manpower / Population** | 👥 | Housing (food → pop) | Garrison, raiders, manning buildings | **No** (population isn't stolen; it can be *killed* in combat) |
+
+**Deferred:** `Research` (unlock ships/raider types), `Faith` (temple line). The
+schema reserves room for these without requiring them at launch.
+
+### Production model
+- Each production building has a `ratePerHour` at its current level.
+- Resources are **accrued lazily**: on any read/write we compute
+  `gained = ratePerHour * hoursSince(lastTick)`, clamp to storage capacity, then
+  update `lastTick`. No background job needed for accrual.
+- **Storage cap** comes from the Warehouse (+ a small base cap from the Town
+  Center). Production halts when a resource is at cap — this is the idle limit.
+- **Food upkeep:** population consumes food per hour. If food hits 0, population
+  slowly starves (decays) until balanced. This keeps Housing/Farm in tension.
+
+---
+
+## 4. Buildings
+
+Buildings progress through **3 named tiers** (the doc's "Tier 1–10 / 10–20 /
+20–30" columns), each tier internally having multiple upgrade levels. The named
+tiers are cosmetic/identity milestones; the numeric `level` drives stats.
+
+### 4.1 Town Center (island level gate)
+The Town Center (TC) is the heart of the island. Its level **gates** the maximum
+level of every other building (`TClevel` requirement, carried from the original
+`i_BuildingLevel.TClevel`). You raise your whole island by upgrading the TC.
+
+| Tier 1–10 | Tier 10–20 | Tier 20–30 |
+|---|---|---|
+| Campfire | Town Centre | Palace |
+
+### 4.2 Building catalogue
+
+| Category | Function | Tier 1 | Tier 2 | Tier 3 |
+|---|---|---|---|---|
+| **Housing** | Converts Food → Population capacity | Tents | Houses | Villas |
+| **Food** | Food production | Farm | Farm Estate | *(TBD)* |
+| **Wood** | Wood production | Woodcutter | Logging Camp | *(TBD)* |
+| **Stone** | Stone production | Mine | Quarry | *(TBD)* |
+| **Smithing** | Boosts army attack / unlocks units | Smelter | Blacksmith | *(TBD)* |
+| **Army** | Trains & houses land units | Army Camp | Barracks | Army Base |
+| **Walls** | Defensive HP / damage reduction | Palisade Walls | Stone Walls | Reinforced Walls |
+| **Towers** | Auto-damage to attackers | Watch Tower | Guard Tower | Bombard Tower |
+| **Naval** | Builds ships; enables sea raids/range | Dock | Harbour | Port |
+| **Knowledge** | Speeds builds / unlocks (Research later) | Academy | University | *(TBD)* |
+| **Trade** | Generates Currency; resource exchange | Trader | Marketplace | *(TBD)* |
+| **Defense keep** | High-HP last-stand building, loot vault | Castle | Keep | *(TBD)* |
+| **Warehouse** | Increases storage capacity (idle window) | Warehouse | *(TBD)* | *(TBD)* |
+
+> **Vault note (from brainstorm):** the Castle/Keep line doubles as a **vault**
+> that protects a limited amount of resources from being raided (see §6.4).
+
+### 4.3 Upgrade mechanics
+- Each `(building, level)` defines: resource costs, build **Time**, the required
+  **TC level**, a `Function` hook (e.g. `produce`, `store`, `defend`, `train`)
+  and a `FunctAttribute` (the magnitude — rate, cap, HP, etc.). This mirrors the
+  original `i_BuildingLevel` columns and keeps building behaviour **data-driven**
+  rather than hard-coded.
+- Only **one upgrade in progress at a time** in v1 (the `upgrading` flag from the
+  original `i_Building_Island`). The Knowledge line can reduce build times. A
+  second build queue slot is a candidate upgrade later.
+- Players may **rush** a build with Currency (instant finish).
+
+---
+
+## 5. Units & Army
+
+| Field | Purpose |
+|---|---|
+| `Type` | Land / Naval / Defensive (carried from original `i_Unit.Type`) |
+| Cost | Food + Currency + Population to train |
+| Stats | Attack, HP, loot capacity, upkeep |
+
+- Units are trained at the **Army** (land) or **Naval** (ships) buildings, capped
+  by building level and available Population.
+- **Loot capacity** determines how much a successful raid can carry home.
+- Training consumes Population; losing units in combat frees that Population back
+  into the pool over time (re-recruitable), but the killed units themselves are
+  gone.
+
+Launch unit set (small, expandable via data):
+- **Land:** Raider (cheap, low loot), Soldier (defender), Champion (TC-gated elite).
+- **Naval:** Longboat (enables raiding members flagged as "across the water" /
+  extends range), later tiers via Research.
+
+---
+
+## 6. PvP Raiding (core competitive loop)
+
+### 6.1 Initiating a raid
+`/raid @member` (or via the target's island image button). Validations:
+- Attacker has idle (not-defending, not-traveling) units.
+- Target is **not under a protection shield** (§6.3).
+- Attacker is **not on raid cooldown**.
+- Optional **matchmaking guardrail:** target's TC level must be within a band of
+  the attacker's (e.g. ±N) to prevent stomping newbies. `/scout` reveals an
+  estimate of a target's defenses for a small Currency cost.
+
+### 6.2 Combat resolution (instant, server-side)
+1. Compute attacker power = Σ(unit attack × count) × smithing multiplier.
+2. Compute defender power = Σ(garrison defense) + wall HP mitigation + tower
+   auto-damage (towers remove a % of attacking units before the clash).
+3. Resolve in a single deterministic-with-jitter pass; produce casualties on
+   both sides proportional to the power gap.
+4. If attacker wins, loot = min(loot capacity of surviving raiders, raidable
+   resources above the vault floor) — capped by a **loot percentage** so a raid
+   never fully empties a target.
+5. Walls take damage and must be **repaired with Stone** afterward (brainstorm:
+   "repairing defences after raid").
+
+All outcomes are written to a **raid log** and reported as an embed + a
+post-battle image (attacker/defender losses, loot taken).
+
+### 6.3 Protection & anti-grief
+- **New-player shield:** islands below a TC threshold can't be raided.
+- **Post-raid shield:** after being successfully raided, a target gets a
+  timed protection window so they can recover and log back in.
+- **Raid cooldown:** an attacker can't chain raids; cooldown scales down with
+  Naval/Army upgrades.
+- **Repeat-target limit:** you can't raid the same player again until a cooldown
+  passes, preventing farming one victim.
+
+### 6.4 The Vault (Castle/Keep)
+A portion of resources (scaling with Castle/Keep level) is **unraidable** — it
+sits in the vault. This guarantees that active-but-unlucky players never lose
+*everything*, and gives the defense line a clear economic value.
+
+---
+
+## 7. Player Interaction & UX
+
+Per the locked decision, Islander uses **both** slash commands *and* an
+interactive image-with-buttons surface.
+
+### 7.1 Slash commands
+| Command | Description |
+|---|---|
+| `/island [@member]` | Render your island (or view another's) — image + status embed + action buttons. |
+| `/build <building>` | Start constructing a new building. |
+| `/upgrade <building>` | Upgrade an existing building (or via button). |
+| `/train <unit> <count>` | Train army/naval units. |
+| `/raid @member` | Launch a raid. |
+| `/scout @member` | Pay Currency to estimate a target's defenses. |
+| `/repair` | Spend Stone to repair walls after a raid. |
+| `/collect` | Force a resource tick / claim (mostly cosmetic, since accrual is lazy). |
+| `/island-leaderboard` | Top islands by a power score (TC level + buildings + army). |
+| `/island-help` | Tutorial / command reference. |
+
+All long operations **`deferReply`** first (Discord's 3s rule, per `CLAUDE.md`).
+
+### 7.2 Interactive surface
+`/island` renders:
+- A **generated PNG** of the island via `@napi-rs/canvas`, drawing each built
+  building at its `imagePosX/Y` using `imagename` sprites (this is exactly what
+  the original `i_BuildingLevel.imagename / imagePosX / imagePosY` columns were
+  for, and reuses the same canvas tech as `AchievementsModule` profile images).
+- A **status embed**: resource bars (current/cap), population, army summary,
+  active build timer, shield/cooldown status.
+- **Action buttons / select menus**: Build, Upgrade, Train, Raid, Repair,
+  Refresh. Button `customId`s are namespaced `islander:<action>:<arg>` and routed
+  by the existing button-handler pattern (`name` === customId prefix).
+
+### 7.3 Notifications
+- Build-complete and "you were raided" pings respect the member's existing
+  `NotifyLevel` preference (`modules/NotificationLevels.ts`).
+- An optional dedicated island-updates channel can reuse
+  `islander/ChannelUpdates.ts` (currently a generic helper — see §11).
+
+---
+
+## 8. Game Balance & Tuning
+
+All balance lives in **data** (the `*_Level` tables), never in code, so tuning is
+a DB edit + cache refresh — no redeploy.
+
+- **Costs/time** grow roughly geometrically per level; the Knowledge line and
+  Currency rushing provide pressure valves.
+- **Loot %** and **vault floor** are the primary PvP balance levers.
+- **Protection windows** and **TC matchmaking band** are the primary anti-grief
+  levers.
+- A simple **power score** (used for leaderboard + matchmaking) =
+  `w1·TClevel + w2·Σ(buildingLevels) + w3·armyValue`.
+- Seed numbers belong in a companion `ISLANDER_BALANCE.md` (follow-up), kept out
+  of this design doc so tuning churn doesn't pollute the spec.
+
+---
+
+## 9. Technical Design
+
+Islander follows the codebase's established patterns: **static module classes**
+for logic, **`IHandler` files** for commands/buttons, the **global Prisma
+client**, and the **custom logger**. See `CLAUDE.md` for the conventions.
+
+### 9.1 Module layout
+```
+islander/
+├── ChannelUpdates.ts        # existing helper (see §11)
+├── IslanderModule.ts        # core: island CRUD, resource ticks, build/upgrade
+├── CombatModule.ts          # raid resolution, loot, casualties, raid log
+├── IslanderImage.ts         # @napi-rs/canvas island renderer
+├── IslanderEmbeds.ts        # status / battle-report embed builders
+└── data/                    # (optional) seed definitions if not DB-seeded
+interactionHandlers/commands/
+├── island.ts, build.ts, upgrade.ts, train.ts, raid.ts, scout.ts, repair.ts ...
+interactionHandlers/buttons/
+└── islander.ts              # routes islander:<action> button customIds
+```
+Resource accrual is **lazy** (computed on access in `IslanderModule`), so no new
+cron is required. A light hourly cron may handle starvation/shield expiry sweeps
+if lazy evaluation proves insufficient (reuse `modules/statistics.ts` cron
+style).
+
+### 9.2 Proposed Prisma schema
+This refines the removed `i_*` models and adds PvP support (raid log, shields,
+cooldowns, timers). Field names follow the original where sensible for an easy
+revival path.
+
+```prisma
+model i_Island {
+  ID            String   @id @db.VarChar(25)        // = Members.ID
+  Wood          Int      @default(0) @db.UnsignedInt
+  Stone         Int      @default(0) @db.UnsignedInt
+  Currency      Int      @default(0) @db.UnsignedInt
+  Food          Int      @default(0) @db.UnsignedInt
+  Manpower      Int      @default(0) @db.UnsignedInt
+  Population    Int      @default(0) @db.UnsignedInt // trained + idle pop
+  LastTick      DateTime @default(now())            // for lazy accrual
+  ShieldUntil   DateTime?                            // PvP protection window
+  RaidCooldown  DateTime?                            // attacker cooldown
+  Members       Members            @relation(fields: [ID], references: [ID], onUpdate: Restrict)
+  Buildings     i_Building_Island[]
+  Units         i_Unit_Island[]
+  RaidsSent     i_Raid[]           @relation("Attacker")
+  RaidsRecv     i_Raid[]           @relation("Defender")
+}
+
+model i_Building {
+  ID     Int               @id @default(autoincrement())
+  Name   String?           @db.VarChar(255)
+  Levels i_BuildingLevel[]
+  Built  i_Building_Island[]
+}
+
+model i_BuildingLevel {
+  BuildingID     Int
+  Level          Int     @db.UnsignedTinyInt
+  Name           String  @db.VarChar(255)   // tier name e.g. "Logging Camp"
+  Wood           Int     @default(0) @db.UnsignedMediumInt
+  Food           Int     @default(0) @db.UnsignedMediumInt
+  Stone          Int     @default(0) @db.UnsignedMediumInt
+  Time           Int     @default(0) @db.UnsignedMediumInt  // build seconds
+  TClevel        Int?    @default(0) @db.UnsignedTinyInt    // TC gate
+  imagename      String  @default("") @db.VarChar(255)
+  imagePosX      Int     @default(0) @db.MediumInt
+  imagePosY      Int     @default(0) @db.MediumInt
+  Function       String? @default("none") @db.VarChar(25)  // produce|store|defend|train|trade
+  FunctAttribute Int?    @default(0)                        // rate|cap|HP|...
+  i_Building     i_Building @relation(fields: [BuildingID], references: [ID], onDelete: Cascade)
+  Built          i_Building_Island[]
+  @@id([BuildingID, Level])
+}
+
+model i_Building_Island {
+  BuildingID   Int
+  IslandID     String    @db.VarChar(25)
+  level        Int       @default(1) @db.UnsignedTinyInt
+  upgrading    Int?                          // target level while building
+  upgradeReady DateTime?                      // when current build completes
+  wallHP       Int?      @default(0)          // for wall/tower lines
+  i_BuildingLevel i_BuildingLevel @relation(fields: [level, BuildingID], references: [Level, BuildingID])
+  i_Island        i_Island        @relation(fields: [IslandID], references: [ID], onDelete: Cascade)
+  i_Building      i_Building      @relation(fields: [BuildingID], references: [ID])
+  @@id([BuildingID, IslandID])
+}
+
+model i_Unit {
+  ID     Int     @id @default(autoincrement()) @db.UnsignedInt
+  Name   String  @db.VarChar(255)
+  Type   Int     @db.UnsignedTinyInt   // 0=land,1=naval,2=defense
+  Attack Int     @default(0)
+  HP     Int     @default(0)
+  Loot   Int     @default(0)           // carry capacity
+  Islands i_Unit_Island[]
+}
+
+model i_Unit_Island {
+  IslandID String   @db.VarChar(25)
+  UnitID   Int      @db.UnsignedInt
+  count    Int      @db.UnsignedSmallInt
+  i_Unit   i_Unit   @relation(fields: [UnitID], references: [ID], onDelete: Cascade)
+  i_Island i_Island @relation(fields: [IslandID], references: [ID], onDelete: Cascade)
+  @@id([IslandID, UnitID])
+}
+
+model i_Raid {
+  ID          Int      @id @default(autoincrement())
+  AttackerID  String   @db.VarChar(25)
+  DefenderID  String   @db.VarChar(25)
+  TimeStamp   DateTime @default(now())
+  AttackerWon Boolean
+  LootWood    Int      @default(0)
+  LootStone   Int      @default(0)
+  LootFood    Int      @default(0)
+  LootCurrency Int     @default(0)
+  Report      String   @db.Text     // serialized casualty/loot detail (JSON)
+  Attacker    i_Island @relation("Attacker", fields: [AttackerID], references: [ID])
+  Defender    i_Island @relation("Defender", fields: [DefenderID], references: [ID])
+  @@index([AttackerID]) @@index([DefenderID]) @@index([TimeStamp])
+}
+```
+Add `i_Island i_Island?` back to the `Members` model (the exact relation removed
+in `88417ca`). Run `npx prisma generate` + a migration after applying.
+
+### 9.3 Caching
+- Building/Unit/Level definitions are static-ish → load once into an in-memory
+  cache on `clientReady`, invalidated by an admin `/island-reload` command.
+- Per-island state is read live from Prisma (with lazy tick on read).
+
+---
+
+## 10. Future Points / Economy Integration (designed, off at launch)
+
+Hooks to add later **without schema churn**:
+1. **Achievement milestones:** award existing Achievements/Points (one-way) for
+   reaching TC tiers, winning N raids, etc. Uses `AchievementsModule`.
+2. **Points → Currency exchange:** a rate-limited, capped conversion so the
+   community economy can feed the game without unbalancing it. Gated behind a
+   config flag.
+3. **Shop crossover:** cosmetic island skins purchasable with Points via the
+   existing Reward shop.
+
+Each is additive and feature-flagged; none are required for v1.
+
+---
+
+## 11. Cleanup / Tech Debt Notes
+
+- `islander/ChannelUpdates.ts` is **not** island-game code today — it's a generic
+  helper that posts profile/raid-event messages to an update channel. It only
+  lives under `islander/` historically. Either (a) keep it and let Islander reuse
+  it for island update broadcasts, or (b) move it to `modules/` and treat
+  `islander/` as purely the new game. **Recommendation:** keep it, extend it.
+- `CLAUDE.md` still lists `i_Island / i_Building / i_Unit` and describes
+  `islander/` as "Island game mechanics module" — that documentation is stale
+  until this feature lands. Update it as part of implementation.
+
+---
+
+## 12. Phased Delivery Plan
+
+| Phase | Scope | Outcome |
+|---|---|---|
+| **0 — Foundations** | Schema + migration, building/unit seed data, `IslanderModule` with lazy resource ticks, `/island` (image + embed). | Players have an island and watch resources grow. |
+| **1 — Build loop** | `/build`, `/upgrade`, Warehouse caps, TC gating, build timers, Currency rush, action buttons. | Full single-player progression. |
+| **2 — Army** | `/train`, unit data, Smithing/Naval effects, population/upkeep tension. | Players field an army. |
+| **3 — PvP** | `CombatModule`, `/raid`, `/scout`, `/repair`, shields, cooldowns, loot caps, vault, raid log, battle report image. | The competitive core loop is live. |
+| **4 — Polish & social** | Leaderboard, notifications, tutorial, balance pass via `ISLANDER_BALANCE.md`. | Tuned, discoverable, retention features. |
+| **5 — Integrations (optional)** | Points/achievement hooks (§10), cosmetics. | Ties Islander into the wider community economy. |
+
+---
+
+## Appendix A — Source Material
+
+- **Original brainstorm:** `FPG_discord_island_builder.docx` (resources,
+  buildings, 3-tier progression table). Open items in the doc (`?` Research,
+  `?` Faith, `?` Temple, vault, "currency generation unclear") are resolved or
+  deferred above.
+- **Abandoned implementation:** the `i_*` Prisma models removed in `88417ca`
+  ("refactor: remove unused models from schema.prisma"). §9.2 revives and extends
+  them. There was never any game *logic* committed — only the schema.
+- **Reusable tech in-repo:** `@napi-rs/canvas` image generation
+  (`AchievementsModule` / `modules/profile.js`), the `IHandler` command/button
+  pattern, the global Prisma client, cron style in `modules/statistics.ts`, and
+  `modules/NotificationLevels.ts`.

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -431,6 +431,13 @@ model i_Raid {
 Add `i_Island i_Island?` back to the `Members` model (the exact relation removed
 in `88417ca`). Run `npx prisma generate` + a migration after applying.
 
+> **Implemented (Phase 0):** the live schema is in `prisma/schema.prisma` with
+> migration `prisma/migrations/20260604000000_add_islander_game`. It extends the
+> sketch above with a few practical columns: `i_Island.Population` / `CreatedAt`,
+> `i_BuildingLevel.Currency` (Currency build costs), `i_Building_Island.wallHP`,
+> and per-unit cost/stat columns on `i_Unit` (`Wood`/`Food`/`Currency`/`Pop`/
+> `Attack`/`HP`/`Loot`/`TrainTime`).
+
 ### 9.3 Caching
 - Building/Unit/Level definitions are static-ish → load once into an in-memory
   cache on `clientReady`, invalidated by an admin `/island-reload` command.
@@ -470,7 +477,7 @@ Each is additive and feature-flagged; none are required for v1.
 
 | Phase | Scope | Outcome |
 |---|---|---|
-| **0 — Foundations** | Schema + migration, building/unit seed data, `IslanderModule` with lazy resource ticks, `/island` (image + embed). | Players have an island and watch resources grow. |
+| **0 — Foundations** ✅ | Schema + migration, building/unit seed data (`islander/data/balance.ts` + `IslanderSeed`), `IslanderModule` with lazy resource ticks, `/island` (image + embed + Refresh button). | **Implemented.** Players have an island and watch resources grow. |
 | **1 — Build loop** | `/build`, `/upgrade`, Warehouse caps, TC gating, build timers, Currency rush, action buttons. | Full single-player progression. |
 | **2 — Army** | `/train`, unit data, Smithing/Naval effects, population/upkeep tension. | Players field an army. |
 | **3 — PvP** | `CombatModule`, `/raid`, `/scout`, `/repair`, shields, cooldowns, loot caps, vault, raid log, battle report image. | The competitive core loop is live. |

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -66,10 +66,18 @@ Five core resources (carried over from the brainstorm). Two "maybe" resources
 | **Currency** | 🪙 | Trade buildings + raiding | Trading, instant-finish, rush upgrades | Yes |
 | **Manpower / Population** | 👥 | Housing (food → pop) | Garrison, raiders, manning buildings | **No** (population isn't stolen; it can be *killed* in combat) |
 
-**Deferred:** `Research` (unlock ships/raider types), `Faith` (temple line). The
-schema reserves room for these without requiring them at launch.
+### 3.1 Deferred resources (later phases)
+Two "maybe" resources from the brainstorm are intentionally **out of v1** but the
+schema leaves room for them (add columns to `i_Island` + new `produce`/`boost`
+building rows — no structural change):
+- **Research** — accumulated at the **Knowledge** line; spent to unlock new
+  ship/raider unit types and special abilities. Turns Knowledge from a pure
+  build-time discount into a tech tree.
+- **Faith** — produced by a deferred **Temple** line; candidate uses include a
+  defensive blessing (temporary shield) or a production buff. Kept vague until a
+  phase actually needs it.
 
-### Production model
+### 3.2 Production model
 - Each production building has a `ratePerHour` at its current level.
 - Resources are **accrued lazily**: on any read/write we compute
   `gained = ratePerHour * hoursSince(lastTick)`, clamp to storage capacity, then
@@ -98,35 +106,67 @@ level of every other building (`TClevel` requirement, carried from the original
 
 ### 4.2 Building catalogue
 
-| Category | Function | Tier 1 | Tier 2 | Tier 3 |
-|---|---|---|---|---|
-| **Housing** | Converts Food → Population capacity | Tents | Houses | Villas |
-| **Food** | Food production | Farm | Farm Estate | *(TBD)* |
-| **Wood** | Wood production | Woodcutter | Logging Camp | *(TBD)* |
-| **Stone** | Stone production | Mine | Quarry | *(TBD)* |
-| **Smithing** | Boosts army attack / unlocks units | Smelter | Blacksmith | *(TBD)* |
-| **Army** | Trains & houses land units | Army Camp | Barracks | Army Base |
-| **Walls** | Defensive HP / damage reduction | Palisade Walls | Stone Walls | Reinforced Walls |
-| **Towers** | Auto-damage to attackers | Watch Tower | Guard Tower | Bombard Tower |
-| **Naval** | Builds ships; enables sea raids/range | Dock | Harbour | Port |
-| **Knowledge** | Speeds builds / unlocks (Research later) | Academy | University | *(TBD)* |
-| **Trade** | Generates Currency; resource exchange | Trader | Marketplace | *(TBD)* |
-| **Defense keep** | High-HP last-stand building, loot vault | Castle | Keep | *(TBD)* |
-| **Warehouse** | Increases storage capacity (idle window) | Warehouse | *(TBD)* | *(TBD)* |
+The catalogue is complete below: each line has three named forms (Tier 1 / 2 / 3)
+swapping in across the level bands. `Function` is the data hook in
+`i_BuildingLevel.Function`; `Effect` is what `FunctAttribute` scales. The
+brainstorm only named two forms for several lines (and just one for the
+Warehouse) — the **bold-italic** names are this design's additions to give every
+line a full three-tier progression. Per-level numbers live in
+[`ISLANDER_BALANCE.md`](./ISLANDER_BALANCE.md).
 
-> **Vault note (from brainstorm):** the Castle/Keep line doubles as a **vault**
-> that protects a limited amount of resources from being raided (see §6.4).
+| Category | Function | Effect (what scales) | Tier 1 | Tier 2 | Tier 3 |
+|---|---|---|---|---|---|
+| **Town Center** | `gate` | Caps all other buildings' level; +base storage | Campfire | Town Centre | Palace |
+| **Housing** | `store` | Population capacity (Food → pop) | Tents | Houses | Villas |
+| **Food** | `produce` | Food / hour | Farm | Farm Estate | ***Plantation*** |
+| **Wood** | `produce` | Wood / hour | Woodcutter | Logging Camp | ***Sawmill*** |
+| **Stone** | `produce` | Stone / hour | Mine | Quarry | ***Stoneworks*** |
+| **Trade** | `trade` | Currency / hour + exchange volume | Trader | Marketplace | ***Grand Bazaar*** |
+| **Warehouse** | `store` | Storage cap for all resources (idle window) | Warehouse | ***Storehouse*** | ***Grand Depot*** |
+| **Smithing** | `boost` | +% army Attack & HP; unlocks units | Smelter | Blacksmith | ***Foundry*** |
+| **Army** | `train` | Land-unit cap; training | Army Camp | Barracks | Army Base |
+| **Naval** | `train` | Ship cap; enables/extends raids; cooldown cut | Dock | Harbour | Port |
+| **Knowledge** | `boost` | −% build time; (Research unlocks later) | Academy | University | ***Grand Library*** |
+| **Walls** | `defend` | Wall HP + incoming damage reduction | Palisade Walls | Stone Walls | Reinforced Walls |
+| **Towers** | `defend` | Pre-battle % of attackers killed | Watch Tower | Guard Tower | Bombard Tower |
+| **Keep** | `vault` | % + flat resources protected from raids | Castle | Keep | ***Citadel*** |
+
+Notes on specific lines:
+- **Town Center** is the master gate (full detail in §4.1). No building may exceed
+  the TC's level.
+- **Trade** answers the brainstorm's open *"how is Currency generated?"* —
+  Currency is produced (slowly) here and is the main raiding reward. The
+  Marketplace+ tiers also enable a capped **resource exchange** (§4.5).
+- **Knowledge** reduces build times globally; it is also the future home of the
+  deferred **Research** resource (unlocking ship/raider types) — see §3.1.
+- **Keep** line is a **late-unlock** defensive line (Castle first appears at a
+  high TC, per balance) and doubles as the **vault** (§6.4). The brainstorm named
+  only Castle → Keep; *Citadel* is added as the Tier-3 form.
 
 ### 4.3 Upgrade mechanics
 - Each `(building, level)` defines: resource costs, build **Time**, the required
-  **TC level**, a `Function` hook (e.g. `produce`, `store`, `defend`, `train`)
-  and a `FunctAttribute` (the magnitude — rate, cap, HP, etc.). This mirrors the
+  **TC level**, a `Function` hook (`gate`, `produce`, `store`, `trade`, `boost`,
+  `train`, `defend`, `vault` — see the §4.2 catalogue) and a `FunctAttribute`
+  (the magnitude — rate, cap, HP, %, etc.). This mirrors the
   original `i_BuildingLevel` columns and keeps building behaviour **data-driven**
   rather than hard-coded.
 - Only **one upgrade in progress at a time** in v1 (the `upgrading` flag from the
   original `i_Building_Island`). The Knowledge line can reduce build times. A
   second build queue slot is a candidate upgrade later.
 - Players may **rush** a build with Currency (instant finish).
+
+### 4.4 Deferred buildings (later phases)
+These appear in the brainstorm with a `?` and are **not** part of v1, but the
+data-driven schema accommodates them with no structural change:
+- **Temple line** → produces the deferred **Faith** resource.
+- **Research building** → folded into the **Knowledge** line above (Academy/
+  University/Grand Library) when Research is enabled.
+
+### 4.5 Resource exchange (Trade line)
+Once a Marketplace (Trade Tier 2) is built, players may convert one resource into
+another at an unfavourable ratio, with a per-day volume cap that scales with the
+building level. This is a pressure valve for lopsided stockpiles — never a
+free-money pump. Exact ratio and cap live in the balance doc (§7 there).
 
 ---
 
@@ -145,10 +185,22 @@ level of every other building (`TClevel` requirement, carried from the original
   into the pool over time (re-recruitable), but the killed units themselves are
   gone.
 
-Launch unit set (small, expandable via data):
-- **Land:** Raider (cheap, low loot), Soldier (defender), Champion (TC-gated elite).
-- **Naval:** Longboat (enables raiding members flagged as "across the water" /
-  extends range), later tiers via Research.
+### Launch roster
+Small and data-driven; new units (and the Research gate) come later. Stats live
+in [`ISLANDER_BALANCE.md`](./ISLANDER_BALANCE.md) §8.
+
+| Unit | Type | Role | Trained at | Notes |
+|---|---|---|---|---|
+| **Raider** | Land | Glass-cannon looter — high loot, low HP | Army Camp | The offensive workhorse; dies fast on defense. |
+| **Soldier** | Land | Cheap HP wall — high HP, low loot | Army Camp | The backbone of a garrison. |
+| **Champion** | Land | Elite all-rounder | Barracks (Army Tier 2) | TC/Barracks-gated; strong attack *and* HP. |
+| **Longboat** | Naval | Loot hauler / raid enabler | Dock | Required to reach a target; carries the bulk of loot home. |
+| **War Galley** | Naval | Heavy naval power + huge loot | Harbour (Naval Tier 2) | Late-game loot capacity and ship combat. |
+
+Design intent: without ships even a *won* raid carries little loot back, so the
+Naval line gates meaningful raiding; Raiders maximise theft but bleed on defense,
+pushing players to keep a separate Soldier garrison. Future unit types
+(e.g. Research-gated specialists) slot in as new `i_Unit` rows.
 
 ---
 
@@ -321,7 +373,7 @@ model i_BuildingLevel {
   imagename      String  @default("") @db.VarChar(255)
   imagePosX      Int     @default(0) @db.MediumInt
   imagePosY      Int     @default(0) @db.MediumInt
-  Function       String? @default("none") @db.VarChar(25)  // produce|store|defend|train|trade
+  Function       String? @default("none") @db.VarChar(25)  // gate|produce|store|trade|boost|train|defend|vault
   FunctAttribute Int?    @default(0)                        // rate|cap|HP|...
   i_Building     i_Building @relation(fields: [BuildingID], references: [ID], onDelete: Cascade)
   Built          i_Building_Island[]

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -247,8 +247,9 @@ a DB edit + cache refresh — no redeploy.
   levers.
 - A simple **power score** (used for leaderboard + matchmaking) =
   `w1·TClevel + w2·Σ(buildingLevels) + w3·armyValue`.
-- Seed numbers belong in a companion `ISLANDER_BALANCE.md` (follow-up), kept out
-  of this design doc so tuning churn doesn't pollute the spec.
+- Concrete seed numbers (production rates, costs, build times, unit stats, PvP
+  levers) live in the companion **[`ISLANDER_BALANCE.md`](./ISLANDER_BALANCE.md)**,
+  kept out of this design doc so tuning churn doesn't pollute the spec.
 
 ---
 

--- a/interactionHandlers/buttons/islander.ts
+++ b/interactionHandlers/buttons/islander.ts
@@ -1,0 +1,46 @@
+import { ButtonInteraction } from "discord.js";
+import { IHandler } from "../../interfaces/IHandler";
+import { IslanderView } from "../../islander/IslanderView";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("IslanderButton");
+
+// Routes islander_* button interactions. customId format:
+//   islander_<action>_<arg>
+// Phase 0 handles `refresh`; build/upgrade/train/raid buttons are disabled in
+// the UI until their phases land. See docs/ISLANDER_DESIGN.md §7.2 / §12.
+export default class IslanderButton implements IHandler {
+  name = "islander";
+
+  async execute(interaction: ButtonInteraction) {
+    const parts = interaction.customId.split("_");
+    const action = parts[1];
+    const arg = parts[2];
+
+    try {
+      if (action === "refresh") {
+        await interaction.deferUpdate();
+        const target = await global.client.users.fetch(arg).catch(() => null);
+        const message = await IslanderView.build(
+          arg,
+          target?.username ?? "Island"
+        );
+        await interaction.editReply(message);
+        return;
+      }
+
+      // Disabled placeholders shouldn't reach here, but guard anyway.
+      await interaction.reply({
+        content: "That action isn't available yet — coming in a later update.",
+        ephemeral: true,
+      });
+    } catch (error) {
+      log.error(`Failed to handle islander button '${action}':`, error);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction
+          .reply({ content: "Something went wrong.", ephemeral: true })
+          .catch(() => {});
+      }
+    }
+  }
+}

--- a/interactionHandlers/commands/island.ts
+++ b/interactionHandlers/commands/island.ts
@@ -1,0 +1,45 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  User,
+} from "discord.js";
+import { IHandler } from "../../interfaces/IHandler";
+import { IslanderView } from "../../islander/IslanderView";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("IslandCommand");
+
+// /island [member] — render your island (or another member's): image + status
+// embed + action buttons. Creates the island on first use. See
+// docs/ISLANDER_DESIGN.md §7.
+export default class IslandCommand implements IHandler {
+  name = "island";
+  isGuild = true;
+  data = new SlashCommandBuilder()
+    .setName("island")
+    .setDescription("View your Islander island (or another member's)")
+    .addUserOption((opt) =>
+      opt
+        .setName("member")
+        .setDescription("Whose island to view (defaults to you)")
+        .setRequired(false)
+    ) as SlashCommandBuilder;
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+    try {
+      const target: User =
+        interaction.options.getUser("member") ?? interaction.user;
+      const message = await IslanderView.build(
+        target.id,
+        target.username
+      );
+      await interaction.editReply(message);
+    } catch (error) {
+      log.error("Failed to render island:", error);
+      await interaction.editReply({
+        content: "Something went wrong loading that island. Try again shortly.",
+      });
+    }
+  }
+}

--- a/islander/IslanderEmbeds.ts
+++ b/islander/IslanderEmbeds.ts
@@ -1,0 +1,72 @@
+// Discord embed builders for Islander. See docs/ISLANDER_DESIGN.md §7.2.
+
+import { EmbedBuilder } from "discord.js";
+import { lineByKey, tierNameFor, ResourceKey } from "./data/balance";
+import { IslandWithDetail, IslanderModule } from "./IslanderModule";
+
+export abstract class IslanderEmbeds {
+  static status(
+    island: IslandWithDetail,
+    ownerName: string,
+    opts: {
+      cap: number;
+      popCap: number;
+      production: Record<ResourceKey, number>;
+      tcLevel: number;
+    }
+  ): EmbedBuilder {
+    const { cap, popCap, production, tcLevel } = opts;
+
+    const resLine = (
+      label: string,
+      value: number,
+      perHour: number,
+      capped = true
+    ) =>
+      `${label}: **${value}**${capped ? `/${cap}` : ""}` +
+      (perHour ? ` (+${perHour}/h)` : "");
+
+    const buildings = (island.Buildings ?? [])
+      .map((b: any) => {
+        const line = lineByKey(b.i_Building?.Name);
+        return line ? `${tierNameFor(line, b.level)} (Lv ${b.level})` : null;
+      })
+      .filter(Boolean)
+      .sort();
+
+    const embed = new EmbedBuilder()
+      .setColor("#FD8612")
+      .setTitle(`🏝️ ${ownerName}'s Island`)
+      .setDescription(`Town Center level **${tcLevel}**`)
+      .addFields(
+        {
+          name: "Resources",
+          value: [
+            resLine("🪵 Wood", island.Wood, production.Wood),
+            resLine("🪨 Stone", island.Stone, production.Stone),
+            resLine("🍖 Food", island.Food, production.Food),
+            resLine("🪙 Currency", island.Currency, production.Currency, false),
+          ].join("\n"),
+          inline: true,
+        },
+        {
+          name: "Population",
+          value: `👥 **${island.Population}**/${popCap}`,
+          inline: true,
+        },
+        {
+          name: `Buildings (${buildings.length})`,
+          value: buildings.length ? buildings.join("\n") : "None yet",
+          inline: false,
+        }
+      )
+      .setImage("attachment://island.png")
+      .setFooter({
+        text: "Islander · FPG kraken bot",
+        iconURL: "https://flamingpalm.com/images/FlamingPalmLogoSmall.png",
+      })
+      .setTimestamp();
+
+    return embed;
+  }
+}

--- a/islander/IslanderImage.ts
+++ b/islander/IslanderImage.ts
@@ -1,0 +1,91 @@
+// Renders an island to a PNG via @napi-rs/canvas. This is a procedural
+// placeholder: it draws water, the island, and each built building as a labelled
+// marker at its catalogue position (imagePosX/Y). Once sprite assets exist they
+// can be drawn with Canvas.loadImage in place of the markers, keyed by
+// i_BuildingLevel.imagename. See docs/ISLANDER_DESIGN.md §7.2.
+
+import * as Canvas from "@napi-rs/canvas";
+import { AttachmentBuilder } from "discord.js";
+import { lineByKey, tierNameFor } from "./data/balance";
+import { IslandWithDetail, IslanderModule } from "./IslanderModule";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("IslanderImage");
+
+const WIDTH = 600;
+const HEIGHT = 400;
+
+export abstract class IslanderImage {
+  static async render(
+    island: IslandWithDetail,
+    ownerName: string
+  ): Promise<AttachmentBuilder> {
+    const buffer = await this.renderBuffer(island, ownerName);
+    return new AttachmentBuilder(buffer, { name: "island.png" });
+  }
+
+  static async renderBuffer(
+    island: IslandWithDetail,
+    ownerName: string
+  ): Promise<Buffer> {
+    const canvas = Canvas.createCanvas(WIDTH, HEIGHT);
+    const ctx = canvas.getContext("2d");
+
+    try {
+      // Sea
+      const sea = ctx.createLinearGradient(0, 0, 0, HEIGHT);
+      sea.addColorStop(0, "#2b6cb0");
+      sea.addColorStop(1, "#1a4971");
+      ctx.fillStyle = sea;
+      ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+      // Island landmass
+      ctx.fillStyle = "#caa472";
+      ctx.beginPath();
+      ctx.ellipse(WIDTH / 2, HEIGHT / 2 + 30, 250, 150, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#5fa05f";
+      ctx.beginPath();
+      ctx.ellipse(WIDTH / 2, HEIGHT / 2 + 20, 220, 120, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Buildings
+      for (const b of island.Buildings ?? []) {
+        const line = lineByKey(b.i_Building?.Name);
+        if (!line) continue;
+        const x = line.posX;
+        const y = line.posY;
+        ctx.fillStyle = "rgba(40,30,20,0.75)";
+        ctx.fillRect(x - 26, y - 16, 52, 24);
+        ctx.fillStyle = "#ffffff";
+        ctx.font = "11px sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText(tierNameFor(line, b.level), x, y - 4);
+        ctx.font = "9px sans-serif";
+        ctx.fillStyle = "#ffd27f";
+        ctx.fillText(`Lv ${b.level}`, x, y + 5);
+      }
+
+      // Header banner with resources
+      ctx.fillStyle = "rgba(0,0,0,0.55)";
+      ctx.fillRect(0, 0, WIDTH, 34);
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 16px sans-serif";
+      ctx.textAlign = "left";
+      ctx.fillText(`${ownerName}'s Island`, 12, 23);
+
+      const cap = IslanderModule.storageCap(island);
+      ctx.font = "13px sans-serif";
+      ctx.textAlign = "right";
+      ctx.fillText(
+        `Wood ${island.Wood}/${cap}  Stone ${island.Stone}/${cap}  Food ${island.Food}/${cap}  Coin ${island.Currency}`,
+        WIDTH - 10,
+        22
+      );
+    } catch (error) {
+      log.error("Failed to render island image:", error);
+    }
+
+    return canvas.toBuffer("image/png");
+  }
+}

--- a/islander/IslanderModule.ts
+++ b/islander/IslanderModule.ts
@@ -1,0 +1,237 @@
+// Islander core logic: island lifecycle + lazy resource accrual.
+//
+// Resources are accrued lazily — there is no per-tick cron. On every read we
+// compute what was produced since `LastTick`, clamp to storage, and persist.
+// See docs/ISLANDER_DESIGN.md §3.2 / §9.1.
+
+import {
+  CONSTANTS,
+  BUILDING_LINES,
+  lineByKey,
+  levelStats,
+  ResourceKey,
+} from "./data/balance";
+import { IslanderSeed } from "./IslanderSeed";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("IslanderModule");
+
+// Island with the relations the module needs. Loosely typed (strict: false).
+export type IslandWithDetail = any;
+
+export abstract class IslanderModule {
+  // line key -> i_Building.ID, populated by ensureDefinitions().
+  private static buildingIdByKey: Map<string, number> | null = null;
+
+  /** Ensure definition tables are seeded and the id cache is warm. */
+  static async ensureDefinitions(): Promise<Map<string, number>> {
+    if (this.buildingIdByKey) return this.buildingIdByKey;
+    const prisma = global.client.prisma;
+
+    const count = await prisma.i_Building.count();
+    if (count === 0) {
+      log.info("No Islander definitions found — seeding from balance data");
+      await IslanderSeed.upsertAll();
+    }
+
+    const buildings = await prisma.i_Building.findMany();
+    const map = new Map<string, number>();
+    for (const b of buildings) if (b.Name) map.set(b.Name, b.ID);
+    this.buildingIdByKey = map;
+    return map;
+  }
+
+  /** Force a re-seed and cache refresh (admin /island-reload). */
+  static async reload(): Promise<void> {
+    await IslanderSeed.upsertAll();
+    this.buildingIdByKey = null;
+    await this.ensureDefinitions();
+  }
+
+  /** Fetch the island (with buildings + units), creating it if needed. */
+  static async getOrCreateIsland(userId: string): Promise<IslandWithDetail> {
+    const prisma = global.client.prisma;
+    const ids = await this.ensureDefinitions();
+
+    let island = await this.fetch(userId);
+    if (island) return island;
+
+    // Ensure a Members row exists (FK target) without clobbering existing data.
+    await prisma.members.upsert({
+      where: { ID: userId },
+      update: {},
+      create: { ID: userId, DisplayName: global.client.idToName(userId) ?? userId },
+    });
+
+    await prisma.i_Island.create({
+      data: {
+        ID: userId,
+        Wood: CONSTANTS.START.Wood,
+        Stone: CONSTANTS.START.Stone,
+        Food: CONSTANTS.START.Food,
+        Currency: CONSTANTS.START.Currency,
+        Population: CONSTANTS.START.Population,
+        LastTick: new Date(),
+      },
+    });
+
+    // Place the starter buildings at level 1.
+    for (const key of CONSTANTS.STARTER_BUILDINGS) {
+      const buildingId = ids.get(key);
+      if (!buildingId) continue;
+      const line = lineByKey(key);
+      const wallHP = line?.func === "defend" ? levelStats(line, 1).attr : 0;
+      await prisma.i_Building_Island.create({
+        data: { BuildingID: buildingId, IslandID: userId, level: 1, wallHP },
+      });
+    }
+
+    log.info(`Created new island for ${userId}`);
+    return this.fetch(userId);
+  }
+
+  /** Read an island with its buildings + units, or null if none. */
+  static async fetch(userId: string): Promise<IslandWithDetail> {
+    return global.client.prisma.i_Island.findUnique({
+      where: { ID: userId },
+      include: {
+        Buildings: { include: { i_Building: true } },
+        Units: { include: { i_Unit: true } },
+      },
+    });
+  }
+
+  /** Town Center level (drives the build-level gate + base storage). */
+  static townCenterLevel(island: IslandWithDetail): number {
+    const tc = island.Buildings?.find(
+      (b: any) => b.i_Building?.Name === "towncenter"
+    );
+    return tc?.level ?? 1;
+  }
+
+  /** Per-resource storage cap from TC level + warehouse buildings. */
+  static storageCap(island: IslandWithDetail): number {
+    let cap =
+      CONSTANTS.BASE_STORAGE +
+      this.townCenterLevel(island) * CONSTANTS.TC_STORAGE_PER_LEVEL;
+    for (const b of island.Buildings ?? []) {
+      const line = lineByKey(b.i_Building?.Name);
+      if (line?.func === "store" && line.resource === "all") {
+        cap += levelStats(line, b.level).attr;
+      }
+    }
+    return cap;
+  }
+
+  /** Population capacity from housing buildings. */
+  static populationCap(island: IslandWithDetail): number {
+    let cap = CONSTANTS.START.Population;
+    for (const b of island.Buildings ?? []) {
+      const line = lineByKey(b.i_Building?.Name);
+      if (line?.func === "store" && line.resource === "Population") {
+        cap += levelStats(line, b.level).attr;
+      }
+    }
+    return cap;
+  }
+
+  /** Production per hour for each gatherable resource. */
+  static productionPerHour(island: IslandWithDetail): Record<ResourceKey, number> {
+    const out: Record<ResourceKey, number> = {
+      Wood: 0, Stone: 0, Food: 0, Currency: 0, Population: 0,
+    };
+    for (const b of island.Buildings ?? []) {
+      const line = lineByKey(b.i_Building?.Name);
+      if (!line) continue;
+      if (line.func === "produce" && line.resource && line.resource !== "all") {
+        out[line.resource as ResourceKey] += levelStats(line, b.level).attr;
+      } else if (line.func === "trade") {
+        out.Currency += levelStats(line, b.level).attr;
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Apply lazy accrual since LastTick: add production (clamped to cap), grow or
+   * starve population, persist, and return the refreshed island.
+   */
+  static async applyTick(island: IslandWithDetail): Promise<IslandWithDetail> {
+    const now = Date.now();
+    const last = new Date(island.LastTick).getTime();
+    const hours = Math.max(0, (now - last) / 3_600_000);
+    if (hours <= 0) return island;
+
+    const cap = this.storageCap(island);
+    const prod = this.productionPerHour(island);
+    const clamp = (v: number) => Math.max(0, Math.min(cap, Math.round(v)));
+
+    const wood = clamp(island.Wood + prod.Wood * hours);
+    const stone = clamp(island.Stone + prod.Stone * hours);
+    const currency = clamp(island.Currency + prod.Currency * hours);
+
+    // Food: production minus population upkeep.
+    const upkeep = island.Population * CONSTANTS.FOOD_UPKEEP_PER_POP * hours;
+    let food = clamp(island.Food + prod.Food * hours - upkeep);
+
+    // Population: grow toward capacity if fed, else starve.
+    const popCap = this.populationCap(island);
+    let population = island.Population;
+    if (island.Food + prod.Food * hours - upkeep <= 0 && population > 0) {
+      population = Math.max(
+        0,
+        Math.round(population * (1 - CONSTANTS.STARVATION_RATE * hours))
+      );
+    } else if (population < popCap) {
+      population = Math.min(
+        popCap,
+        population + Math.ceil(popCap * CONSTANTS.POP_GROWTH_RATE * hours)
+      );
+    }
+
+    await global.client.prisma.i_Island.update({
+      where: { ID: island.ID },
+      data: {
+        Wood: wood,
+        Stone: stone,
+        Food: food,
+        Currency: currency,
+        Population: population,
+        LastTick: new Date(now),
+      },
+    });
+
+    // Reflect changes on the in-memory object so callers needn't re-fetch.
+    island.Wood = wood;
+    island.Stone = stone;
+    island.Food = food;
+    island.Currency = currency;
+    island.Population = population;
+    island.LastTick = new Date(now);
+    return island;
+  }
+
+  /** One-call entry point for commands: create/fetch + tick + derived stats. */
+  static async getIslandView(userId: string): Promise<{
+    island: IslandWithDetail;
+    cap: number;
+    popCap: number;
+    production: Record<ResourceKey, number>;
+    tcLevel: number;
+  }> {
+    let island = await this.getOrCreateIsland(userId);
+    island = await this.applyTick(island);
+    return {
+      island,
+      cap: this.storageCap(island),
+      popCap: this.populationCap(island),
+      production: this.productionPerHour(island),
+      tcLevel: this.townCenterLevel(island),
+    };
+  }
+
+  /** Definitions sanity helper (used by tests/diagnostics). */
+  static get lines() {
+    return BUILDING_LINES;
+  }
+}

--- a/islander/IslanderSeed.ts
+++ b/islander/IslanderSeed.ts
@@ -1,0 +1,87 @@
+// Seeds the Islander definition tables (i_Building, i_BuildingLevel, i_Unit)
+// from islander/data/balance.ts. Idempotent — safe to run repeatedly (used by
+// IslanderModule.ensureDefinitions and a future /island-reload admin command).
+
+import { BUILDING_LINES, UNITS, levelStats } from "./data/balance";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("IslanderSeed");
+
+export abstract class IslanderSeed {
+  /** Upsert every building line + its levels and every unit definition. */
+  static async upsertAll(): Promise<void> {
+    const prisma = global.client.prisma;
+
+    for (const line of BUILDING_LINES) {
+      // One i_Building row per line, keyed by the stable line key in Name.
+      let building = await prisma.i_Building.findFirst({
+        where: { Name: line.key },
+      });
+      if (!building) {
+        building = await prisma.i_Building.create({ data: { Name: line.key } });
+      }
+
+      for (let level = 1; level <= line.maxLevel; level++) {
+        const s = levelStats(line, level);
+        await prisma.i_BuildingLevel.upsert({
+          where: { BuildingID_Level: { BuildingID: building.ID, Level: level } },
+          create: {
+            BuildingID: building.ID,
+            Level: level,
+            Name: s.name,
+            Wood: s.wood,
+            Stone: s.stone,
+            Food: s.food,
+            Currency: s.currency,
+            Time: s.time,
+            TClevel: s.tcReq,
+            imagename: line.image,
+            imagePosX: line.posX,
+            imagePosY: line.posY,
+            Function: line.func,
+            FunctAttribute: s.attr,
+          },
+          update: {
+            Name: s.name,
+            Wood: s.wood,
+            Stone: s.stone,
+            Food: s.food,
+            Currency: s.currency,
+            Time: s.time,
+            TClevel: s.tcReq,
+            imagename: line.image,
+            imagePosX: line.posX,
+            imagePosY: line.posY,
+            Function: line.func,
+            FunctAttribute: s.attr,
+          },
+        });
+      }
+    }
+
+    for (const u of UNITS) {
+      const existing = await prisma.i_Unit.findFirst({ where: { Name: u.name } });
+      const data = {
+        Name: u.name,
+        Type: u.type,
+        Wood: u.wood,
+        Food: u.food,
+        Currency: u.currency,
+        Pop: u.pop,
+        Attack: u.attack,
+        HP: u.hp,
+        Loot: u.loot,
+        TrainTime: u.trainTime,
+      };
+      if (existing) {
+        await prisma.i_Unit.update({ where: { ID: existing.ID }, data });
+      } else {
+        await prisma.i_Unit.create({ data });
+      }
+    }
+
+    log.info(
+      `Seeded ${BUILDING_LINES.length} building lines and ${UNITS.length} units`
+    );
+  }
+}

--- a/islander/IslanderView.ts
+++ b/islander/IslanderView.ts
@@ -1,0 +1,65 @@
+// Builds the full /island message payload (embed + island image + action
+// buttons), shared by the slash command and the button handler so the refresh
+// button reproduces exactly what the command renders.
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from "discord.js";
+import { IslanderModule } from "./IslanderModule";
+import { IslanderImage } from "./IslanderImage";
+import { IslanderEmbeds } from "./IslanderEmbeds";
+
+export interface IslandMessage {
+  embeds: any[];
+  files: any[];
+  components: any[];
+}
+
+export abstract class IslanderView {
+  static async build(
+    targetId: string,
+    targetName: string
+  ): Promise<IslandMessage> {
+    const view = await IslanderModule.getIslandView(targetId);
+    const image = await IslanderImage.render(view.island, targetName);
+    const embed = IslanderEmbeds.status(view.island, targetName, {
+      cap: view.cap,
+      popCap: view.popCap,
+      production: view.production,
+      tcLevel: view.tcLevel,
+    });
+
+    // Phase 0: Refresh is live; the rest preview the roadmap (Phase 1-3) and are
+    // disabled until their handlers land.
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`islander_refresh_${targetId}`)
+        .setLabel("Refresh")
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId("islander_build_disabled")
+        .setLabel("Build")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId("islander_upgrade_disabled")
+        .setLabel("Upgrade")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId("islander_train_disabled")
+        .setLabel("Train")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId("islander_raid_disabled")
+        .setLabel("Raid")
+        .setStyle(ButtonStyle.Danger)
+        .setDisabled(true)
+    );
+
+    return { embeds: [embed], files: [image], components: [row] };
+  }
+}

--- a/islander/data/balance.ts
+++ b/islander/data/balance.ts
@@ -1,0 +1,218 @@
+// Islander balance data — the single source of truth for game numbers.
+// Mirrors docs/ISLANDER_BALANCE.md. Used both to SEED the definition tables
+// (i_Building / i_BuildingLevel / i_Unit) and at RUNTIME by IslanderModule.
+//
+// Keeping one TS source avoids drift between the seed and the live maths. The
+// DB definition rows exist for Phase 1+ (build/upgrade cost lookups) and the
+// website; the runtime computes from these helpers directly.
+
+export type ResourceKey = "Wood" | "Stone" | "Food" | "Currency" | "Population";
+export type BuildingFunc =
+  | "gate"
+  | "produce"
+  | "store"
+  | "trade"
+  | "boost"
+  | "train"
+  | "defend"
+  | "vault";
+
+export const CONSTANTS = {
+  BASE_STORAGE: 500, // base per-resource cap from a level-1 Town Center
+  TC_STORAGE_PER_LEVEL: 250, // extra cap per TC level
+  START: { Wood: 300, Stone: 300, Food: 300, Currency: 50, Population: 5 },
+  GROWTH: { COST: 1.55, TIME: 1.5, RATE: 1.35 },
+  TIME_CAP: 86400, // 24h — no single build longer than a day in v1
+  RUSH_SECONDS_PER_CURRENCY: 6, // /6s of remaining build = 1 Currency to finish
+  POP_GROWTH_RATE: 0.02, // fraction of pop capacity gained per hour
+  FOOD_UPKEEP_PER_POP: 0.5, // Food consumed per population per hour
+  STARVATION_RATE: 0.05, // fraction of population lost per hour at 0 Food
+  // Buildings a brand-new island starts with (line keys), all at level 1.
+  STARTER_BUILDINGS: ["towncenter", "food", "wood", "stone", "housing", "warehouse"],
+};
+
+export interface BuildingLine {
+  key: string; // stable identity, stored in i_Building.Name
+  func: BuildingFunc;
+  resource?: ResourceKey | "all"; // target of produce/store
+  tierNames: [string, string, string]; // levels 1-9 / 10-19 / 20+
+  maxLevel: number;
+  unlockTC: number; // min Town Center level to build level 1
+  image: string; // sprite name for i_BuildingLevel.imagename
+  posX: number; // default canvas placement
+  posY: number;
+  base: {
+    wood?: number;
+    stone?: number;
+    food?: number;
+    currency?: number;
+    time: number; // build seconds at level 1
+    attr: number; // FunctAttribute at level 1 (rate / cap / hp / % ...)
+  };
+}
+
+// Catalogue (docs/ISLANDER_DESIGN.md §4.2). base values anchor the growth curve.
+export const BUILDING_LINES: BuildingLine[] = [
+  {
+    key: "towncenter", func: "gate", tierNames: ["Campfire", "Town Centre", "Palace"],
+    maxLevel: 30, unlockTC: 0, image: "towncenter", posX: 280, posY: 200,
+    base: { wood: 150, stone: 120, food: 80, time: 120, attr: 0 },
+  },
+  {
+    key: "housing", func: "store", resource: "Population",
+    tierNames: ["Tents", "Houses", "Villas"], maxLevel: 30, unlockTC: 1,
+    image: "housing", posX: 150, posY: 250,
+    base: { wood: 40, stone: 20, time: 45, attr: 10 },
+  },
+  {
+    key: "food", func: "produce", resource: "Food",
+    tierNames: ["Farm", "Farm Estate", "Plantation"], maxLevel: 30, unlockTC: 1,
+    image: "farm", posX: 100, posY: 180,
+    base: { wood: 50, stone: 30, time: 30, attr: 60 },
+  },
+  {
+    key: "wood", func: "produce", resource: "Wood",
+    tierNames: ["Woodcutter", "Logging Camp", "Sawmill"], maxLevel: 30, unlockTC: 1,
+    image: "woodcutter", posX: 420, posY: 170,
+    base: { wood: 40, stone: 20, time: 30, attr: 55 },
+  },
+  {
+    key: "stone", func: "produce", resource: "Stone",
+    tierNames: ["Mine", "Quarry", "Stoneworks"], maxLevel: 30, unlockTC: 1,
+    image: "mine", posX: 470, posY: 240,
+    base: { wood: 40, stone: 20, time: 30, attr: 55 },
+  },
+  {
+    key: "trade", func: "trade", resource: "Currency",
+    tierNames: ["Trader", "Marketplace", "Grand Bazaar"], maxLevel: 30, unlockTC: 8,
+    image: "trader", posX: 350, posY: 260,
+    base: { wood: 120, stone: 100, time: 600, attr: 20 },
+  },
+  {
+    key: "warehouse", func: "store", resource: "all",
+    tierNames: ["Warehouse", "Storehouse", "Grand Depot"], maxLevel: 30, unlockTC: 1,
+    image: "warehouse", posX: 210, posY: 180,
+    base: { wood: 60, stone: 40, time: 60, attr: 1000 },
+  },
+  {
+    key: "smithing", func: "boost",
+    tierNames: ["Smelter", "Blacksmith", "Foundry"], maxLevel: 30, unlockTC: 5,
+    image: "smelter", posX: 320, posY: 150,
+    base: { wood: 150, stone: 200, time: 600, attr: 3 }, // +3% army atk/hp per level
+  },
+  {
+    key: "army", func: "train",
+    tierNames: ["Army Camp", "Barracks", "Army Base"], maxLevel: 30, unlockTC: 3,
+    image: "army", posX: 180, posY: 300,
+    base: { wood: 200, stone: 120, food: 150, time: 600, attr: 30 }, // land-unit cap = 30*level
+  },
+  {
+    key: "naval", func: "train",
+    tierNames: ["Dock", "Harbour", "Port"], maxLevel: 30, unlockTC: 5,
+    image: "dock", posX: 520, posY: 320,
+    base: { wood: 250, stone: 150, time: 900, attr: 5 }, // ship cap = 5*level
+  },
+  {
+    key: "knowledge", func: "boost",
+    tierNames: ["Academy", "University", "Grand Library"], maxLevel: 30, unlockTC: 8,
+    image: "academy", posX: 250, posY: 130,
+    base: { wood: 180, stone: 160, time: 1200, attr: 1 }, // -1% build time per level
+  },
+  {
+    key: "walls", func: "defend",
+    tierNames: ["Palisade Walls", "Stone Walls", "Reinforced Walls"], maxLevel: 30, unlockTC: 3,
+    image: "walls", posX: 60, posY: 320,
+    base: { wood: 100, stone: 200, time: 300, attr: 500 }, // wall HP
+  },
+  {
+    key: "towers", func: "defend",
+    tierNames: ["Watch Tower", "Guard Tower", "Bombard Tower"], maxLevel: 30, unlockTC: 5,
+    image: "tower", posX: 540, posY: 130,
+    base: { wood: 120, stone: 150, time: 300, attr: 2 }, // pre-battle kill % per level
+  },
+  {
+    key: "keep", func: "vault",
+    tierNames: ["Castle", "Keep", "Citadel"], maxLevel: 15, unlockTC: 15,
+    image: "castle", posX: 300, posY: 230,
+    base: { wood: 2000, stone: 3000, time: 7200, attr: 15 }, // vault % protected
+  },
+];
+
+export interface UnitDef {
+  key: string;
+  name: string;
+  type: number; // 0 = land, 1 = naval, 2 = defense
+  wood: number;
+  food: number;
+  currency: number;
+  pop: number;
+  attack: number;
+  hp: number;
+  loot: number;
+  trainTime: number;
+}
+
+// Roster (docs/ISLANDER_DESIGN.md §5, numbers in ISLANDER_BALANCE.md §8).
+export const UNITS: UnitDef[] = [
+  { key: "raider",   name: "Raider",    type: 0, wood: 15,  food: 20, currency: 0,  pop: 1, attack: 8,  hp: 20,  loot: 50,  trainTime: 60 },
+  { key: "soldier",  name: "Soldier",   type: 0, wood: 25,  food: 25, currency: 0,  pop: 1, attack: 12, hp: 45,  loot: 10,  trainTime: 90 },
+  { key: "champion", name: "Champion",  type: 0, wood: 60,  food: 50, currency: 20, pop: 2, attack: 35, hp: 110, loot: 40,  trainTime: 240 },
+  { key: "longboat", name: "Longboat",  type: 1, wood: 120, food: 30, currency: 10, pop: 3, attack: 25, hp: 150, loot: 300, trainTime: 300 },
+  { key: "galley",   name: "War Galley",type: 1, wood: 300, food: 60, currency: 40, pop: 5, attack: 70, hp: 400, loot: 800, trainTime: 600 },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/** The displayed tier name for a building line at a given level. */
+export function tierNameFor(line: BuildingLine, level: number): string {
+  if (level >= 20) return line.tierNames[2];
+  if (level >= 10) return line.tierNames[1];
+  return line.tierNames[0];
+}
+
+/** Min Town Center level required to hold this building at `level`. */
+export function tcRequirement(line: BuildingLine, level: number): number {
+  return Math.max(level, line.unlockTC);
+}
+
+export interface LevelStats {
+  level: number;
+  name: string;
+  wood: number;
+  stone: number;
+  food: number;
+  currency: number;
+  time: number; // build seconds
+  tcReq: number;
+  attr: number; // FunctAttribute meaning depends on line.func
+}
+
+/** Computed stats for one (line, level) per the documented growth curve. */
+export function levelStats(line: BuildingLine, level: number): LevelStats {
+  const { GROWTH, TIME_CAP } = CONSTANTS;
+  const costMul = Math.pow(GROWTH.COST, level - 1);
+  const time = Math.min(
+    Math.round((line.base.time || 0) * Math.pow(GROWTH.TIME, level - 1)),
+    TIME_CAP
+  );
+  // boost/defend/vault/train scale linearly; produce/store/trade scale geometrically.
+  const linear = ["boost", "defend", "vault", "train"].includes(line.func);
+  const attr = linear
+    ? Math.round(line.base.attr * level)
+    : Math.round(line.base.attr * Math.pow(GROWTH.RATE, level - 1));
+  return {
+    level,
+    name: tierNameFor(line, level),
+    wood: Math.round((line.base.wood || 0) * costMul),
+    stone: Math.round((line.base.stone || 0) * costMul),
+    food: Math.round((line.base.food || 0) * costMul),
+    currency: Math.round((line.base.currency || 0) * costMul),
+    time,
+    tcReq: tcRequirement(line, level),
+    attr,
+  };
+}
+
+export function lineByKey(key: string): BuildingLine | undefined {
+  return BUILDING_LINES.find((l) => l.key === key);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Discord bot for flamingpalm",
   "main": "index.ts",
   "scripts": {
-    "start": "node ./bin/index.js",
+    "start": "npx prisma migrate deploy && node ./bin/index.js",
+    "migrate": "npx prisma migrate deploy",
     "build": "npx tsc",
     "deploy": "npx tsc && node bin/deploy-commands.js"
   },

--- a/prisma/migrations/20260604000000_add_islander_game/migration.sql
+++ b/prisma/migrations/20260604000000_add_islander_game/migration.sql
@@ -1,0 +1,133 @@
+-- CreateTable
+CREATE TABLE `i_Island` (
+    `ID` VARCHAR(25) NOT NULL,
+    `Wood` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Stone` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Currency` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Food` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Manpower` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Population` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `LastTick` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    `ShieldUntil` DATETIME(0) NULL,
+    `RaidCooldown` DATETIME(0) NULL,
+    `CreatedAt` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+
+    PRIMARY KEY (`ID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_Building` (
+    `ID` INTEGER NOT NULL AUTO_INCREMENT,
+    `Name` VARCHAR(255) NULL,
+
+    PRIMARY KEY (`ID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_BuildingLevel` (
+    `BuildingID` INTEGER NOT NULL,
+    `Level` TINYINT UNSIGNED NOT NULL,
+    `Name` VARCHAR(255) NOT NULL,
+    `Wood` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Food` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Stone` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Currency` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Time` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `TClevel` TINYINT UNSIGNED NULL DEFAULT 0,
+    `imagename` VARCHAR(255) NOT NULL DEFAULT '',
+    `imagePosX` MEDIUMINT NOT NULL DEFAULT 0,
+    `imagePosY` MEDIUMINT NOT NULL DEFAULT 0,
+    `Function` VARCHAR(25) NULL DEFAULT 'none',
+    `FunctAttribute` INTEGER NULL DEFAULT 0,
+
+    INDEX `i_BuildingLevel_BuildingID_index`(`BuildingID`),
+    PRIMARY KEY (`BuildingID`, `Level`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_Building_Island` (
+    `BuildingID` INTEGER NOT NULL,
+    `IslandID` VARCHAR(25) NOT NULL,
+    `level` TINYINT UNSIGNED NOT NULL DEFAULT 1,
+    `upgrading` INTEGER NULL,
+    `upgradeReady` DATETIME(0) NULL,
+    `wallHP` INTEGER NULL DEFAULT 0,
+
+    INDEX `IslandID`(`IslandID`),
+    INDEX `i_Building_Island_level_BuildingID_index`(`level`, `BuildingID`),
+    PRIMARY KEY (`BuildingID`, `IslandID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_Unit` (
+    `ID` INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
+    `Name` VARCHAR(255) NOT NULL,
+    `Type` TINYINT UNSIGNED NOT NULL,
+    `Wood` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Food` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Currency` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Pop` SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+    `Attack` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `HP` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `Loot` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+    `TrainTime` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (`ID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_Unit_Island` (
+    `IslandID` VARCHAR(25) NOT NULL,
+    `UnitID` INTEGER UNSIGNED NOT NULL,
+    `count` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+
+    INDEX `UnitID`(`UnitID`),
+    PRIMARY KEY (`IslandID`, `UnitID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `i_Raid` (
+    `ID` INTEGER NOT NULL AUTO_INCREMENT,
+    `AttackerID` VARCHAR(25) NOT NULL,
+    `DefenderID` VARCHAR(25) NOT NULL,
+    `TimeStamp` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    `AttackerWon` BOOLEAN NOT NULL,
+    `LootWood` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `LootStone` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `LootFood` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `LootCurrency` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `Report` TEXT NOT NULL,
+
+    INDEX `i_Raid_AttackerID_index`(`AttackerID`),
+    INDEX `i_Raid_DefenderID_index`(`DefenderID`),
+    INDEX `i_Raid_TimeStamp_index`(`TimeStamp`),
+    PRIMARY KEY (`ID`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `i_Island` ADD CONSTRAINT `i_Island_ibfk_1` FOREIGN KEY (`ID`) REFERENCES `Members`(`ID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `i_BuildingLevel` ADD CONSTRAINT `i_BuildingLevel_ibfk_1` FOREIGN KEY (`BuildingID`) REFERENCES `i_Building`(`ID`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `i_Building_Island` ADD CONSTRAINT `i_Building_Island_level_BuildingID_fk` FOREIGN KEY (`level`, `BuildingID`) REFERENCES `i_BuildingLevel`(`Level`, `BuildingID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `i_Building_Island` ADD CONSTRAINT `i_Building_Island_ibfk_2` FOREIGN KEY (`IslandID`) REFERENCES `i_Island`(`ID`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `i_Building_Island` ADD CONSTRAINT `i_Building_Island_ibfk_3` FOREIGN KEY (`BuildingID`) REFERENCES `i_Building`(`ID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `i_Unit_Island` ADD CONSTRAINT `i_Unit_Island_ibfk_1` FOREIGN KEY (`UnitID`) REFERENCES `i_Unit`(`ID`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `i_Unit_Island` ADD CONSTRAINT `i_Unit_Island_ibfk_2` FOREIGN KEY (`IslandID`) REFERENCES `i_Island`(`ID`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `i_Raid` ADD CONSTRAINT `i_Raid_ibfk_1` FOREIGN KEY (`AttackerID`) REFERENCES `i_Island`(`ID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `i_Raid` ADD CONSTRAINT `i_Raid_ibfk_2` FOREIGN KEY (`DefenderID`) REFERENCES `i_Island`(`ID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "mysql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Members {
   SSReceiver                            SSReceiver?
   SSSender                              SSSender?
   VoiceConnected                        VoiceConnected[]
+  i_Island                              i_Island?
 }
 
 model PointHistory {
@@ -254,4 +255,120 @@ model FreeKeys {
   Redeemer    String? @db.VarChar(10)
   Description String? @db.VarChar(255)
   Key         String? @db.VarChar(255)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Islander — island-building game. See docs/ISLANDER_DESIGN.md (§9.2) and
+// docs/ISLANDER_BALANCE.md. Definition tables (i_Building, i_BuildingLevel,
+// i_Unit) are seeded from islander/data; per-island state lives in i_Island,
+// i_Building_Island and i_Unit_Island. i_Raid is the PvP audit log.
+// ─────────────────────────────────────────────────────────────────────────
+
+model i_Island {
+  ID           String              @id @db.VarChar(25)
+  Wood         Int                 @default(0) @db.UnsignedInt
+  Stone        Int                 @default(0) @db.UnsignedInt
+  Currency     Int                 @default(0) @db.UnsignedInt
+  Food         Int                 @default(0) @db.UnsignedInt
+  Manpower     Int                 @default(0) @db.UnsignedInt
+  Population   Int                 @default(0) @db.UnsignedInt
+  LastTick     DateTime            @default(now()) @db.DateTime(0)
+  ShieldUntil  DateTime?           @db.DateTime(0)
+  RaidCooldown DateTime?           @db.DateTime(0)
+  CreatedAt    DateTime            @default(now()) @db.DateTime(0)
+  Members      Members             @relation(fields: [ID], references: [ID], onUpdate: Restrict, map: "i_Island_ibfk_1")
+  Buildings    i_Building_Island[]
+  Units        i_Unit_Island[]
+  RaidsSent    i_Raid[]            @relation("Attacker")
+  RaidsRecv    i_Raid[]            @relation("Defender")
+}
+
+model i_Building {
+  ID     Int                 @id @default(autoincrement())
+  Name   String?             @db.VarChar(255)
+  Levels i_BuildingLevel[]
+  Built  i_Building_Island[]
+}
+
+model i_BuildingLevel {
+  BuildingID     Int
+  Level          Int                 @db.UnsignedTinyInt
+  Name           String              @db.VarChar(255)
+  Wood           Int                 @default(0) @db.UnsignedMediumInt
+  Food           Int                 @default(0) @db.UnsignedMediumInt
+  Stone          Int                 @default(0) @db.UnsignedMediumInt
+  Currency       Int                 @default(0) @db.UnsignedMediumInt
+  Time           Int                 @default(0) @db.UnsignedMediumInt
+  TClevel        Int?                @default(0) @db.UnsignedTinyInt
+  imagename      String              @default("") @db.VarChar(255)
+  imagePosX      Int                 @default(0) @db.MediumInt
+  imagePosY      Int                 @default(0) @db.MediumInt
+  Function       String?             @default("none") @db.VarChar(25)
+  FunctAttribute Int?                @default(0)
+  i_Building     i_Building          @relation(fields: [BuildingID], references: [ID], onDelete: Cascade, map: "i_BuildingLevel_ibfk_1")
+  Built          i_Building_Island[]
+
+  @@id([BuildingID, Level])
+  @@index([BuildingID], map: "i_BuildingLevel_BuildingID_index")
+}
+
+model i_Building_Island {
+  BuildingID      Int
+  IslandID        String          @db.VarChar(25)
+  level           Int             @default(1) @db.UnsignedTinyInt
+  upgrading       Int?
+  upgradeReady    DateTime?       @db.DateTime(0)
+  wallHP          Int?            @default(0)
+  i_BuildingLevel i_BuildingLevel @relation(fields: [level, BuildingID], references: [Level, BuildingID], onUpdate: Restrict, map: "i_Building_Island_level_BuildingID_fk")
+  i_Island        i_Island        @relation(fields: [IslandID], references: [ID], onDelete: Cascade, onUpdate: Restrict, map: "i_Building_Island_ibfk_2")
+  i_Building      i_Building      @relation(fields: [BuildingID], references: [ID], onUpdate: Restrict, map: "i_Building_Island_ibfk_3")
+
+  @@id([BuildingID, IslandID])
+  @@index([IslandID], map: "IslandID")
+  @@index([level, BuildingID], map: "i_Building_Island_level_BuildingID_index")
+}
+
+model i_Unit {
+  ID            Int             @id @default(autoincrement()) @db.UnsignedInt
+  Name          String          @db.VarChar(255)
+  Type          Int             @db.UnsignedTinyInt
+  Wood          Int             @default(0) @db.UnsignedMediumInt
+  Food          Int             @default(0) @db.UnsignedMediumInt
+  Currency      Int             @default(0) @db.UnsignedMediumInt
+  Pop           Int             @default(1) @db.UnsignedSmallInt
+  Attack        Int             @default(0) @db.UnsignedMediumInt
+  HP            Int             @default(0) @db.UnsignedMediumInt
+  Loot          Int             @default(0) @db.UnsignedMediumInt
+  TrainTime     Int             @default(0) @db.UnsignedMediumInt
+  i_Unit_Island i_Unit_Island[]
+}
+
+model i_Unit_Island {
+  IslandID String   @db.VarChar(25)
+  UnitID   Int      @db.UnsignedInt
+  count    Int      @default(0) @db.UnsignedSmallInt
+  i_Unit   i_Unit   @relation(fields: [UnitID], references: [ID], onDelete: Cascade, map: "i_Unit_Island_ibfk_1")
+  i_Island i_Island @relation(fields: [IslandID], references: [ID], onDelete: Cascade, map: "i_Unit_Island_ibfk_2")
+
+  @@id([IslandID, UnitID])
+  @@index([UnitID], map: "UnitID")
+}
+
+model i_Raid {
+  ID           Int      @id @default(autoincrement())
+  AttackerID   String   @db.VarChar(25)
+  DefenderID   String   @db.VarChar(25)
+  TimeStamp    DateTime @default(now()) @db.DateTime(0)
+  AttackerWon  Boolean
+  LootWood     Int      @default(0) @db.UnsignedInt
+  LootStone    Int      @default(0) @db.UnsignedInt
+  LootFood     Int      @default(0) @db.UnsignedInt
+  LootCurrency Int      @default(0) @db.UnsignedInt
+  Report       String   @db.Text
+  Attacker     i_Island @relation("Attacker", fields: [AttackerID], references: [ID], onUpdate: Restrict, map: "i_Raid_ibfk_1")
+  Defender     i_Island @relation("Defender", fields: [DefenderID], references: [ID], onUpdate: Restrict, map: "i_Raid_ibfk_2")
+
+  @@index([AttackerID], map: "i_Raid_AttackerID_index")
+  @@index([DefenderID], map: "i_Raid_DefenderID_index")
+  @@index([TimeStamp], map: "i_Raid_TimeStamp_index")
 }


### PR DESCRIPTION
## Summary
Introduces **Islander**, a new Discord-native island-building game for the FlamingPalm community. This is Phase 0 (MVP): players can view their persistent island, see resource production, and interact with a rendered island image. Future phases will add building/upgrading, unit training, and PvP raiding.

## Key Changes

### Documentation
- **`docs/ISLANDER_DESIGN.md`** (501 lines): Complete game design document covering:
  - Design goals & pillars (idle-friendly, build→power→raid→defend loop, Discord-first UX)
  - Core decisions (self-contained economy, full PvP raiding, slash commands + image + buttons)
  - Resource system (Wood, Stone, Food, Currency, Population with lazy accrual model)
  - Building catalogue (13 lines × 3 tiers: Town Center, Housing, Production, Trade, Military, Defense, Vault)
  - Units & Army (5 unit types: Raider, Soldier, Champion, Longboat, War Galley)
  - PvP raiding mechanics (protection shields, cooldowns, loot caps, wall damage)
  - Schema design (§9.2) mapping to Prisma models

- **`docs/ISLANDER_BALANCE.md`** (315 lines): Concrete tuning numbers:
  - Global constants (storage caps, tick granularity, starvation rates, rush costs)
  - Cost/time growth curves (1.55× cost, 1.50× time, 1.35× production per level)
  - Per-building stats (Town Center levels 1–30, production rates, storage, military, defense)
  - Unit stats (attack, HP, loot capacity, training costs)
  - PvP balance (raid cooldowns, protection windows, loot percentages, wall repair costs)

### Database Schema
- **`prisma/schema.prisma`**: Added 6 new models:
  - `i_Island` — per-player island state (resources, population, shields, raid cooldown, timestamps)
  - `i_Building` — building definitions (keyed by stable `Name` like "towncenter")
  - `i_BuildingLevel` — per-level stats (costs, build time, TC requirement, Function/FunctAttribute for data-driven behavior)
  - `i_Building_Island` — player's built buildings (level, upgrade progress, wall HP)
  - `i_Unit` — unit definitions (type, costs, stats, training time)
  - `i_Unit_Island` — player's trained units (count per unit type)
  - `i_Raid` — audit log for PvP raids (attacker/defender, loot, casualties, timestamps)

- **`prisma/migrations/20260604000000_add_islander_game/migration.sql`**: SQL migration creating all tables with proper indexes and foreign keys

### Core Game Logic
- **`islander/IslanderModule.ts`** (237 lines): Central game engine:
  - `getOrCreateIsland()` — creates new islands with starter buildings
  - `applyTick()` — lazy resource accrual (computes production since last tick, clamps to storage, handles population growth/starvation)
  - `storageCap()`, `populationCap()`, `productionPerHour()` — computed from building levels
  - `townCenterLevel()` — gates all other building upgrades

- **`islander/data/balance.ts`** (218 lines): Single source of truth for all game numbers:
  - `CONSTANTS` — global tuning (storage, growth curves, upkeep rates, starter resources)
  - `BUILDING_LINES` — 13 building definitions with tier names, costs, production rates, unlock requirements
  - `UNITS` — 5 unit types with stats
  - `levelStats()` — computes per-level costs/times/rates using exponential growth curves
  - `lineByKey()`, `tierNameFor()` — lookup helpers for runtime and seeding

- **`islander/IslanderSeed.ts`** (87 lines): Idempotent seeding:

https://claude.ai/code/session_01RLGerwLYHAtQnhtwcnurD2