### PR TITLE
fix(deploy): baseline legacy migration before deploy on startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,12 +156,14 @@ npm run migrate  # Apply pending DB migrations only (prisma migrate deploy)
 npm run deploy   # Build + register slash commands with Discord
 ```
 
-> **Note:** `npm start` runs `prisma migrate deploy` before launching the bot, so
-> pending migrations are applied on every (re)start — including CapRover deploys,
-> whose `CMD` is `npm start`. `migrate deploy` is idempotent and needs no shadow
-> DB. If the DB predates Prisma's migration history, baseline it once with
-> `npx prisma migrate resolve --applied <migration_name>` so `deploy` doesn't try
-> to re-run already-applied migrations.
+> **Note:** `npm start` runs `prisma/migrate-deploy.js` before launching the bot,
+> so pending migrations are applied on every (re)start — including CapRover
+> deploys, whose `CMD` is `npm start`. The `discordstats` DB predates Prisma's
+> migration history (introspected, no `_prisma_migrations` table, legacy
+> `Timezone` column already present), so the script first **baselines** the
+> legacy migration(s) listed in `LEGACY_MIGRATIONS` as already-applied, then runs
+> `migrate deploy`. Both steps are idempotent. When you add a migration that is
+> already reflected in the live schema, append its name to `LEGACY_MIGRATIONS`.
 
 > **Note:** There is no test suite — tests were removed in a previous refactor. `tsconfig.test.json` is a leftover artifact.
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Discord bot for flamingpalm",
   "main": "index.ts",
   "scripts": {
-    "start": "npx prisma migrate deploy && node ./bin/index.js",
-    "migrate": "npx prisma migrate deploy",
+    "start": "node prisma/migrate-deploy.js && node ./bin/index.js",
+    "migrate": "node prisma/migrate-deploy.js",
     "build": "npx tsc",
     "deploy": "npx tsc && node bin/deploy-commands.js"
   },

--- a/prisma/migrate-deploy.js
+++ b/prisma/migrate-deploy.js
@@ -1,0 +1,45 @@
+// Startup migration runner. Applies pending Prisma migrations before the bot
+// boots (invoked by `npm start`).
+//
+// Why this exists: the `discordstats` database predates Prisma's migration
+// history — it was introspected, so there is no `_prisma_migrations` table and
+// the legacy `Timezone` column already exists. A plain `prisma migrate deploy`
+// would try to replay the legacy migration first and fail with "duplicate
+// column", never reaching later migrations. So we first BASELINE the legacy
+// migration as already-applied, then deploy. Both steps are idempotent and safe
+// to run on every boot.
+//
+// Plain JS on purpose: it runs via `node` directly (not compiled by tsc) and
+// only shells out to the Prisma CLI, which is present in node_modules.
+
+const { execSync } = require("child_process");
+
+// Migrations that existed before Prisma migrate was adopted, in order. Their
+// effects are already present in the live schema, so they must be recorded as
+// applied rather than re-run.
+const LEGACY_MIGRATIONS = ["20260311000000_add_timezone_to_members"];
+
+function run(cmd) {
+  console.log(`[migrate] $ ${cmd}`);
+  execSync(cmd, { stdio: "inherit" });
+}
+
+try {
+  for (const name of LEGACY_MIGRATIONS) {
+    // First boot on an introspected DB: creates _prisma_migrations and records
+    // this migration as applied. Later boots: errors "already recorded", which
+    // we deliberately ignore. A real connection error here will resurface from
+    // `migrate deploy` below and abort startup.
+    try {
+      run(`npx prisma migrate resolve --applied ${name}`);
+    } catch (e) {
+      console.log(`[migrate] baseline of ${name} skipped (already applied)`);
+    }
+  }
+
+  run("npx prisma migrate deploy");
+  console.log("[migrate] migrations up to date");
+} catch (e) {
+  console.error("[migrate] migrate deploy failed — aborting startup:", e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
The discordstats DB was introspected and has no _prisma_migrations history, so 'migrate deploy' replayed the legacy Timezone migration and aborted on a duplicate-column error before creating the Islander tables.

Add prisma/migrate-deploy.js: idempotently baselines the legacy migration(s) as already-applied (creating _prisma_migrations on first run), then runs 'migrate deploy'. start/migrate scripts now invoke it. Document the behaviour and the LEGACY_MIGRATIONS list in CLAUDE.md.