### PR TITLE
Islander Phases 3–5: PvP raiding, social/polish, opt-in economy hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,8 @@ const raids = await global.client.prisma.raids.findMany(...);
 | `BUGSNAG_API_KEY` | Bugsnag error tracking key |
 | `LOG_LEVEL` | Logger level: DEBUG, INFO, WARN, ERROR |
 | `DISABLE` | Set to skip startup (optional) |
+| `ISLANDER_AWARD_POINTS` | `true` to award community Points for Islander milestones (optional, default off) |
+| `ISLANDER_POINTS_EXCHANGE` | `true` to enable the Points→island-Currency exchange button (optional, default off) |
 | `CAPROVER_GIT_COMMIT_SHA` | Version tracking (optional) |
 
 ### Scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,8 @@ FlamingPalmKrakenV2/
 │   ├── IHandler.ts           # Interface for all interaction handlers
 │   └── IEvent.ts             # Interface for all event handlers
 ├── islander/                 # "Islander" island-building game (see docs/ISLANDER_DESIGN.md)
-│   ├── IslanderModule.ts     # Core: island lifecycle + lazy resource accrual
+│   ├── IslanderModule.ts     # Core: island lifecycle, lazy accrual, build/upgrade/train
+│   ├── CombatModule.ts       # PvP raid resolution + scouting
 │   ├── IslanderSeed.ts       # Seeds i_Building/i_BuildingLevel/i_Unit from balance data
 │   ├── IslanderView.ts       # Builds the /island message payload (embed+image+buttons)
 │   ├── IslanderImage.ts      # @napi-rs/canvas island renderer

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -500,18 +500,26 @@ in `88417ca`). Run `npx prisma generate` + a migration after applying.
 
 ---
 
-## 10. Future Points / Economy Integration (designed, off at launch)
+## 10. Points / Economy Integration (Phase 5 — implemented, off by default)
 
-Hooks to add later **without schema churn**:
-1. **Achievement milestones:** award existing Achievements/Points (one-way) for
-   reaching TC tiers, winning N raids, etc. Uses `AchievementsModule`.
-2. **Points → Currency exchange:** a rate-limited, capped conversion so the
-   community economy can feed the game without unbalancing it. Gated behind a
-   config flag.
-3. **Shop crossover:** cosmetic island skins purchasable with Points via the
-   existing Reward shop.
+All integrations are **feature-flagged via env vars and disabled by default**, so
+the live Points/shop economy is untouched until an admin opts in. No schema churn
+— they reuse the existing `Points`/`PointHistory` models.
 
-Each is additive and feature-flagged; none are required for v1.
+1. **Milestone Point awards** ✅ (`ISLANDER_AWARD_POINTS=true`) — one-way community
+   Points for Islander achievements (TC 5/10/20, win 1/10/50 raids). Idempotent
+   via a `PointHistory` marker (`ISL:milestone:<key>`); amounts are modest to avoid
+   inflating the economy. TC milestones are checked when the owner views `/island`;
+   raid milestones after a winning raid.
+2. **Points → Currency exchange** ✅ (`ISLANDER_POINTS_EXCHANGE=true`) — an
+   **Exchange 🔁** button (own island) converts community Points into island
+   Currency at `POINTS_PER_CURRENCY` (10:1), with a per-day cap
+   (`EXCHANGE_DAILY_POINT_CAP`, 100 pts) recorded via `PointHistory`
+   (`ISL:exchange`). Spends Points (a sink), clamped to island storage.
+3. **Shop crossover** *(deferred)* — cosmetic island skins via the Reward shop.
+   Parked until Phase 6 lands real art (skins need sprites to swap).
+
+Tuning lives in `INTEGRATIONS`/`MILESTONES` in `islander/data/balance.ts`.
 
 ---
 
@@ -537,7 +545,7 @@ Each is additive and feature-flagged; none are required for v1.
 | **2 — Army** ✅ | Train button → unit select → quantity modal; unit unlock gates (Army/Naval level), land/naval caps, free-population cost, Smithing attack/HP bonus, Naval ship cap, Food-upkeep tension; army summary on the island embed. (Instant training; timed queue deferred.) | **Implemented.** Players field an army. |
 | **3 — PvP** ✅ | `CombatModule`; Raid/Scout buttons on others' islands + Repair button on your own; tower pre-kill, wall HP + damage, Castle/Keep vault, loot caps, new-player/post-raid shields, attacker cooldown (Naval-reduced), repeat-target + matchmaking-band guards, `i_Raid` log, battle-report embed. (Battle *image* deferred to Phase 6.) | **Implemented.** The competitive core loop is live. |
 | **4 — Polish & social** ✅ | Leaderboard button (power-score ranking), How-to-play tutorial button, raid + best-effort build-complete notifications (opt-in via `NotifyLevel`). Balance remains a data-only tuning activity in `ISLANDER_BALANCE.md`. | **Implemented.** Tuned, discoverable, retention features. |
-| **5 — Integrations (optional)** | Points/achievement hooks (§10), cosmetics. | Ties Islander into the wider community economy. |
+| **5 — Integrations (optional)** ✅ | Milestone Point awards + Points→Currency exchange (§10), both **feature-flagged off by default**. Shop/skins deferred to post-Phase-6. | **Implemented (opt-in).** Can tie Islander into the community economy when enabled. |
 | **6 — Visual art pass** | Replace the procedural placeholder with composited art from **Kenney.nl** CC0 kits — Hexagon Kit for the island/terrain/building tiles, Pirate & Nature kits for ships/decor (§7.4). Vendor assets under `assets/islander/`, add an `imagename`(+tier)→sprite resolver with marker fallback, a hex-grid layout, and an image cache; reuse the compositor for battle reports. | A real, attractive island image (and battle scenes) instead of labelled boxes. |
 
 ---

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -213,12 +213,15 @@ pushing players to keep a separate Soldier garrison. Future unit types
 ## 6. PvP Raiding (core competitive loop)
 
 ### 6.1 Initiating a raid
-`/raid @member` (or via the target's island image button). Validations:
-- Attacker has idle (not-defending, not-traveling) units.
-- Target is **not under a protection shield** (§6.3).
-- Attacker is **not on raid cooldown**.
-- Optional **matchmaking guardrail:** target's TC level must be within a band of
-  the attacker's (e.g. ±N) to prevent stomping newbies. `/scout` reveals an
+Open the target's island with `/island @member` and press **Raid ⚔️**. The
+raider commits their **entire army** (all land + naval units). Validations:
+- Attacker has units **and at least one ship** (Naval ≥ 1) to reach the island.
+- Target is **not under a protection shield** (§6.3) and not a new player
+  (TC ≥ 5).
+- Attacker is **not on raid cooldown**, and hasn't raided this target in the
+  last 24h (repeat-target guard).
+- **Matchmaking guardrail:** target's TC level must be within ±5 of the
+  attacker's. **Scout 🔭** reveals an
   estimate of a target's defenses for a small Currency cost.
 
 ### 6.2 Combat resolution (instant, server-side)
@@ -261,12 +264,10 @@ interactive image-with-buttons surface.
 | Command | Description |
 |---|---|
 | `/island [@member]` | Render your island (or view another's) — image + status embed + action buttons. **This is the single entry point**: building, upgrading, rushing and training are all done via its buttons/menus, not separate commands. |
-| `/raid @member` | Launch a raid. |
-| `/scout @member` | Pay Currency to estimate a target's defenses. |
-| `/repair` | Spend Stone to repair walls after a raid. |
-| `/collect` | Force a resource tick / claim (mostly cosmetic, since accrual is lazy). |
-| `/island-leaderboard` | Top islands by a power score (TC level + buildings + army). |
-| `/island-help` | Tutorial / command reference. |
+| Raid / Scout | **Buttons on another member's `/island`** — Raid ⚔️ launches a raid, Scout 🔭 pays Currency for a defense estimate. |
+| Repair | **Button on your own `/island`** (enabled when walls are damaged) — spend Stone to restore wall HP. |
+| `/island-leaderboard` | *(planned)* Top islands by a power score (TC level + buildings + army). |
+| `/island-help` | *(planned)* Tutorial / command reference. |
 
 All long operations **`deferReply`** first (Discord's 3s rule, per `CLAUDE.md`).
 
@@ -528,7 +529,7 @@ Each is additive and feature-flagged; none are required for v1.
 | **0 — Foundations** ✅ | Schema + migration, building/unit seed data (`islander/data/balance.ts` + `IslanderSeed`), `IslanderModule` with lazy resource ticks, `/island` (image + embed + Refresh button). | **Implemented.** Players have an island and watch resources grow. |
 | **1 — Build loop** ✅ | Build/Upgrade/Rush driven entirely by `/island` buttons + select menus (no standalone commands), Warehouse caps, TC gating, build timers, one-build-at-a-time, Currency rush, Knowledge build-time reduction. | **Implemented.** Full single-player progression. |
 | **2 — Army** ✅ | Train button → unit select → quantity modal; unit unlock gates (Army/Naval level), land/naval caps, free-population cost, Smithing attack/HP bonus, Naval ship cap, Food-upkeep tension; army summary on the island embed. (Instant training; timed queue deferred.) | **Implemented.** Players field an army. |
-| **3 — PvP** | `CombatModule`, `/raid`, `/scout`, `/repair`, shields, cooldowns, loot caps, vault, raid log, battle report image. | The competitive core loop is live. |
+| **3 — PvP** ✅ | `CombatModule`; Raid/Scout buttons on others' islands + Repair button on your own; tower pre-kill, wall HP + damage, Castle/Keep vault, loot caps, new-player/post-raid shields, attacker cooldown (Naval-reduced), repeat-target + matchmaking-band guards, `i_Raid` log, battle-report embed. (Battle *image* deferred to Phase 6.) | **Implemented.** The competitive core loop is live. |
 | **4 — Polish & social** | Leaderboard, notifications, tutorial, balance pass via `ISLANDER_BALANCE.md`. | Tuned, discoverable, retention features. |
 | **5 — Integrations (optional)** | Points/achievement hooks (§10), cosmetics. | Ties Islander into the wider community economy. |
 | **6 — Visual art pass** | Replace the procedural placeholder with composited art from **Kenney.nl** CC0 kits — Hexagon Kit for the island/terrain/building tiles, Pirate & Nature kits for ships/decor (§7.4). Vendor assets under `assets/islander/`, add an `imagename`(+tier)→sprite resolver with marker fallback, a hex-grid layout, and an image cache; reuse the compositor for battle reports. | A real, attractive island image (and battle scenes) instead of labelled boxes. |

--- a/docs/ISLANDER_DESIGN.md
+++ b/docs/ISLANDER_DESIGN.md
@@ -266,8 +266,8 @@ interactive image-with-buttons surface.
 | `/island [@member]` | Render your island (or view another's) — image + status embed + action buttons. **This is the single entry point**: building, upgrading, rushing and training are all done via its buttons/menus, not separate commands. |
 | Raid / Scout | **Buttons on another member's `/island`** — Raid ⚔️ launches a raid, Scout 🔭 pays Currency for a defense estimate. |
 | Repair | **Button on your own `/island`** (enabled when walls are damaged) — spend Stone to restore wall HP. |
-| `/island-leaderboard` | *(planned)* Top islands by a power score (TC level + buildings + army). |
-| `/island-help` | *(planned)* Tutorial / command reference. |
+| Leaderboard | **Button on `/island`** — top islands by power score (10·TC + 3·Σ building levels + army/10). |
+| How to play | **Button on `/island`** — in-client tutorial embed. |
 
 All long operations **`deferReply`** first (Discord's 3s rule, per `CLAUDE.md`).
 
@@ -283,9 +283,15 @@ All long operations **`deferReply`** first (Discord's 3s rule, per `CLAUDE.md`).
   Refresh. Button `customId`s are namespaced `islander:<action>:<arg>` and routed
   by the existing button-handler pattern (`name` === customId prefix).
 
-### 7.3 Notifications
-- Build-complete and "you were raided" pings respect the member's existing
-  `NotifyLevel` preference (`modules/NotificationLevels.ts`).
+### 7.3 Notifications ✅
+- **"You were raided" DM** fires at raid-resolution time (a real push) to the
+  defender, with a win/loss + loot summary.
+- **Build-complete DM** is best-effort via an in-memory timer scheduled when a
+  build starts (lost on bot restart; the build itself still completes lazily on
+  the next `/island` view regardless).
+- Both respect the member's `NotifyLevel` bitfield (`modules/NotificationLevels.ts`)
+  — they only DM members who have opted into the `EventNotification` flag, so
+  notifications are **opt-in**.
 - An optional dedicated island-updates channel can reuse
   `islander/ChannelUpdates.ts` (currently a generic helper — see §11).
 
@@ -530,7 +536,7 @@ Each is additive and feature-flagged; none are required for v1.
 | **1 — Build loop** ✅ | Build/Upgrade/Rush driven entirely by `/island` buttons + select menus (no standalone commands), Warehouse caps, TC gating, build timers, one-build-at-a-time, Currency rush, Knowledge build-time reduction. | **Implemented.** Full single-player progression. |
 | **2 — Army** ✅ | Train button → unit select → quantity modal; unit unlock gates (Army/Naval level), land/naval caps, free-population cost, Smithing attack/HP bonus, Naval ship cap, Food-upkeep tension; army summary on the island embed. (Instant training; timed queue deferred.) | **Implemented.** Players field an army. |
 | **3 — PvP** ✅ | `CombatModule`; Raid/Scout buttons on others' islands + Repair button on your own; tower pre-kill, wall HP + damage, Castle/Keep vault, loot caps, new-player/post-raid shields, attacker cooldown (Naval-reduced), repeat-target + matchmaking-band guards, `i_Raid` log, battle-report embed. (Battle *image* deferred to Phase 6.) | **Implemented.** The competitive core loop is live. |
-| **4 — Polish & social** | Leaderboard, notifications, tutorial, balance pass via `ISLANDER_BALANCE.md`. | Tuned, discoverable, retention features. |
+| **4 — Polish & social** ✅ | Leaderboard button (power-score ranking), How-to-play tutorial button, raid + best-effort build-complete notifications (opt-in via `NotifyLevel`). Balance remains a data-only tuning activity in `ISLANDER_BALANCE.md`. | **Implemented.** Tuned, discoverable, retention features. |
 | **5 — Integrations (optional)** | Points/achievement hooks (§10), cosmetics. | Ties Islander into the wider community economy. |
 | **6 — Visual art pass** | Replace the procedural placeholder with composited art from **Kenney.nl** CC0 kits — Hexagon Kit for the island/terrain/building tiles, Pirate & Nature kits for ships/decor (§7.4). Vendor assets under `assets/islander/`, add an `imagename`(+tier)→sprite resolver with marker fallback, a hex-grid layout, and an image cache; reuse the compositor for battle reports. | A real, attractive island image (and battle scenes) instead of labelled boxes. |
 

--- a/docs/ISLANDER_TESTING.md
+++ b/docs/ISLANDER_TESTING.md
@@ -134,6 +134,30 @@ and **within ±5 TC** of each other.
 
 ---
 
+## Phase 5 — Economy integrations (opt-in, off by default)
+
+> These do nothing unless the env flags are set. First verify the **default-off**
+> behaviour, then enable and re-test.
+
+- [ ] **Default off:** with neither flag set, no milestone DMs/points are awarded,
+      and there is **no Exchange button** on your island.
+- [ ] Set `ISLANDER_AWARD_POINTS=true`, restart. View `/island` after reaching
+      **TC 5/10/20** → community Points awarded once each (check `/points` and the
+      `PointHistory` rows with `ISL:milestone:` comments). Re-viewing does **not**
+      re-award (idempotent).
+- [ ] Win raids and confirm **raid milestones** (1/10/50 wins) award once each.
+- [ ] Milestone DM arrives only for members opted into `NotifyLevel` bit `2`.
+- [ ] Set `ISLANDER_POINTS_EXCHANGE=true`, restart. An **Exchange 🔁** button shows
+      on your own island.
+- [ ] Exchange flow: button → modal → converts Points → Currency at 10:1; deducts
+      Points (negative `PointHistory` row `ISL:exchange`), adds Currency (clamped to
+      storage cap — excess reported as lost).
+- [ ] **Daily cap:** can't convert more than 100 points/day total; over-cap →
+      refused with remaining allowance.
+- [ ] Exchange with insufficient points → refused, no change.
+
+---
+
 ## Edge cases & things to watch
 
 - [ ] **Refresh** button always re-renders current state (resources ticked).

--- a/docs/ISLANDER_TESTING.md
+++ b/docs/ISLANDER_TESTING.md
@@ -1,0 +1,161 @@
+# Islander — Manual Test Plan
+
+> Covers Phases 0–4. None of this could be run in the build environment (no live
+> MySQL or Discord token), so everything below is **manual verification** to do
+> on a real server. Tick items off as you go.
+>
+> Companion docs: `ISLANDER_DESIGN.md` (mechanics), `ISLANDER_BALANCE.md` (numbers).
+
+---
+
+## 0. Prerequisites & setup
+
+- [ ] **Migration applied.** `i_*` tables exist (`SHOW TABLES LIKE 'i\_%';` → 7 tables).
+      Deploys auto-run it via `npm start` → `prisma/migrate-deploy.js`.
+- [ ] **Commands registered.** Run `npm run deploy`. Only **`/island`** should
+      register (no `/build`, `/upgrade`, `/rush`, `/train` — those are buttons).
+- [ ] **Bot online**, logs show the `island` command + `islander` button/select/modal
+      handlers loaded with no errors.
+- [ ] For notification tests: at least one tester has opted into the
+      `EventNotification` flag in `Members.NotifyLevel` (bit value `2`). Without it,
+      DMs are intentionally **not** sent.
+- [ ] For PvP tests: **two test accounts** (or willing members) — easier if you can
+      grant resources/levels via DB to reach the required states quickly.
+
+> Tip: to fast-forward state for testing, edit rows directly in `i_Island`
+> (resources), `i_Building_Island` (levels), `i_Unit_Island` (unit counts).
+
+---
+
+## Phase 0 — Foundations
+
+- [ ] `/island` with no prior island → creates one; image + embed render.
+- [ ] Embed shows: Town Center level 1, resources with `/cap`, population `/cap`,
+      a starter building list (Campfire, Farm, Woodcutter, Mine, Tents, Warehouse).
+- [ ] Image renders (placeholder art: sea, island, labelled building markers, header).
+- [ ] **Resource accrual:** note Wood/Stone/Food, wait a few minutes (or set
+      `LastTick` back in the DB), `/island` again → resources increased by the
+      per-hour rate, **clamped at the storage cap**.
+- [ ] **Food upkeep / population:** population grows toward its cap over time; with
+      0 Food and population > 0, population slowly starves.
+- [ ] `/island @otherMember` → shows their island (or creates an empty one for them);
+      your build/upgrade buttons are **disabled** on someone else's island.
+
+---
+
+## Phase 1 — Build loop (buttons on `/island`)
+
+- [ ] **TC gating:** on a fresh island only **Upgrade → Town Centre** is available;
+      Build offers nothing until TC rises (walls/army need TC 3, etc.).
+- [ ] **Build:** press **Build** → select menu lists buildable, TC-unlocked lines
+      with cost previews → pick one → ephemeral "🏗️ Building … ready <relative time>".
+- [ ] Build **deducts resources** immediately; insufficient resources → clear
+      "need X more" error.
+- [ ] **One build at a time:** while a build runs, Build/Upgrade buttons are disabled
+      and starting another is refused.
+- [ ] **Upgrade:** press **Upgrade** → select shows `Name → Lv N` with cost → starts;
+      the building keeps working at its old level until the upgrade completes.
+- [ ] **Completion:** after the timer, `/island` (or Refresh) shows the new
+      building/level; production/caps update accordingly.
+- [ ] **Rush:** with a build in progress, **Rush ⚡** finishes it instantly for 🪙
+      and re-renders in place; too little 🪙 → ephemeral error (no charge).
+- [ ] **Warehouse** upgrade raises the storage cap (idle window grows).
+- [ ] **Knowledge** (Academy line) reduces subsequent build times (compare a build
+      time before/after building it).
+- [ ] **"Under construction"** field appears on the embed with a relative ready time.
+
+---
+
+## Phase 2 — Army (Train button)
+
+- [ ] **Unlock gates:** Train offers nothing until an Army Camp exists; Raider needs
+      Army Lv1, Soldier Lv3, Champion Lv10; Longboat needs a Dock, Galley Naval Lv10.
+- [ ] **Train flow:** Train 🪖 → unit select (shows cost/pop/atk) → quantity **modal**
+      → "🪖 Trained N× …".
+- [ ] **Caps:** can't exceed land cap (30×Army level) or naval cap (5×Naval level) —
+      clear error stating how many more fit.
+- [ ] **Free population:** training consumes idle population; with none free →
+      "need N free population" error (grow Housing).
+- [ ] **Resource cost** deducted; insufficient → error.
+- [ ] **Embed Army field** shows roster, free pop, attack (with Smithing bonus),
+      and land/naval caps.
+- [ ] **Smithing** raises the displayed army Attack (build/upgrade Smelter line).
+- [ ] **Upkeep tension:** a large army keeps eating Food (population upkeep) — verify
+      Food drains faster with more units.
+
+---
+
+## Phase 3 — PvP raiding (Scout/Raid on others, Repair on your own)
+
+Set up: attacker with a **ship** (Longboat) + some Raiders, both islands **TC ≥ 5**
+and **within ±5 TC** of each other.
+
+### Validations (each should block with a clear message)
+- [ ] Raid **yourself** → refused.
+- [ ] Raid with **no ship** (no naval unit) → refused.
+- [ ] Raid with **no army** → refused.
+- [ ] Raid a **new player** (defender TC < 5) → refused.
+- [ ] Raid while **on cooldown** → refused with ready time.
+- [ ] Raid a **shielded** defender (just raided) → refused with shield expiry.
+- [ ] Raid a target **outside ±5 TC** → refused.
+- [ ] Raid the **same target twice within 24h** → refused.
+
+### Combat & outcomes
+- [ ] **Scout 🔭** charges 50 🪙 and returns an (estimated) defense report
+      (army/attack/walls/towers); too little 🪙 → refused.
+- [ ] **Raid ⚔️** posts a public **battle-report embed** (win/loss, both sides'
+      losses, loot, wall damage).
+- [ ] **Win:** attacker gains loot (≤ 20% of each *unprotected* resource, ≤ surviving
+      carry capacity, clamped to attacker storage); defender loses those resources.
+- [ ] **Vault:** a defender with a Castle/Keep keeps a protected floor/percentage of
+      resources unraidable (loot never empties them).
+- [ ] **Towers** reduce attacker numbers (heavier losses vs high towers).
+- [ ] **Walls** make a defender much harder to beat; wall HP drops after a raid.
+- [ ] **Casualties** apply to both sides; freed population becomes re-trainable.
+- [ ] **Cooldown** set on attacker after raiding (shorter with higher Naval).
+- [ ] **Post-raid shield** set on a **beaten** defender (not on a repelled attack).
+- [ ] **Repair 🧱** on your own island (enabled only when walls are damaged) restores
+      wall HP for Stone; full walls → button disabled.
+- [ ] A row is written to `i_Raid` for each resolved raid.
+
+---
+
+## Phase 4 — Leaderboard, tutorial, notifications
+
+- [ ] **Leaderboard 🏆** button → ephemeral top-10 by power score, with medals and
+      TC levels; ordering looks right (stronger islands higher).
+- [ ] **How to play ❓** button → tutorial embed (ephemeral).
+- [ ] **Raid notification:** an opted-in defender (NotifyLevel has bit `2`) receives a
+      DM when raided (win → looted/repair prompt; loss → "held"). A member **without**
+      the flag receives **no** DM.
+- [ ] **Build-complete notification:** an opted-in builder receives a DM when a build
+      finishes (best-effort). Note: **lost if the bot restarts** mid-build — the build
+      still completes on the next `/island` view, just without the DM.
+
+---
+
+## Edge cases & things to watch
+
+- [ ] **Refresh** button always re-renders current state (resources ticked).
+- [ ] Clicking action buttons on **someone else's** `/island` message: build/upgrade/
+      train/rush/repair are disabled or refuse with "that's not your island";
+      Scout/Raid/Leaderboard/Help work.
+- [ ] **Concurrency:** two rapid clicks (e.g. double Rush, or two raids) shouldn't
+      double-charge or go negative — watch for any negative resources/counts.
+- [ ] **Storage clamp:** resources never exceed cap; loot beyond attacker cap is lost
+      (expected).
+- [ ] **Large quantities** in the train modal (e.g. asking for more than caps/pop
+      allow) → refused, not partially applied.
+- [ ] No unhandled-promise errors in the bot logs during any of the above.
+
+---
+
+## Known limitations (by design, v1)
+
+- **Training is instant** (capacity/pop/resource-gated, not time-gated) — `trainTime`
+  is reserved for a future timed queue.
+- **Build-complete DMs are best-effort** (in-memory timer; not restart-durable).
+- **Island art is a placeholder** (procedural). Real Kenney.nl art is **Phase 6**.
+- **No battle image yet** — raids report via embed; battle image is **Phase 6**.
+- **Balance numbers are seeded once** from `ISLANDER_BALANCE.md`; re-tuning means
+  editing the data and re-seeding (a `/island-reload` admin command is a follow-up).

--- a/interactionHandlers/buttons/islander.ts
+++ b/interactionHandlers/buttons/islander.ts
@@ -6,6 +6,8 @@ import {
 import { IHandler } from "../../interfaces/IHandler";
 import { IslanderView } from "../../islander/IslanderView";
 import { IslanderModule } from "../../islander/IslanderModule";
+import { CombatModule } from "../../islander/CombatModule";
+import { IslanderEmbeds } from "../../islander/IslanderEmbeds";
 import { levelStats, tierNameFor } from "../../islander/data/balance";
 import { createLogger } from "../../utils/logger";
 
@@ -36,7 +38,12 @@ export default class IslanderButton implements IHandler {
         return;
       }
 
-      // Everything below mutates an island — only its owner may do so.
+      // Raid / scout act AGAINST ownerId (the target), so the attacker is the
+      // clicker — these must run before the owner check below.
+      if (action === "raid") return this.doRaid(interaction, ownerId);
+      if (action === "scout") return this.doScout(interaction, ownerId);
+
+      // Everything below mutates the clicker's OWN island.
       if (interaction.user.id !== ownerId) {
         await interaction.reply({
           content: "That's not your island.",
@@ -48,6 +55,19 @@ export default class IslanderButton implements IHandler {
       if (action === "build") return this.openBuildSelect(interaction, ownerId);
       if (action === "upgrade") return this.openUpgradeSelect(interaction, ownerId);
       if (action === "train") return this.openTrainSelect(interaction, ownerId);
+      if (action === "repair") {
+        const res = await IslanderModule.repairWalls(ownerId);
+        if (!res.ok) {
+          await interaction.reply({ content: res.message, ephemeral: true });
+          return;
+        }
+        await interaction.deferUpdate();
+        const target = await global.client.users.fetch(ownerId).catch(() => null);
+        await interaction.editReply(
+          await IslanderView.build(ownerId, target?.username ?? "Island", true)
+        );
+        return;
+      }
       if (action === "rush") {
         const res = await IslanderModule.rush(ownerId);
         if (!res.ok) {
@@ -170,5 +190,42 @@ export default class IslanderButton implements IHandler {
       components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)],
       ephemeral: true,
     });
+  }
+
+  private async doRaid(interaction: ButtonInteraction, defenderId: string) {
+    await interaction.deferReply(); // public battle report
+    const [attacker, defender] = await Promise.all([
+      global.client.users.fetch(interaction.user.id).catch(() => null),
+      global.client.users.fetch(defenderId).catch(() => null),
+    ]);
+    const res = await CombatModule.resolveRaid(
+      interaction.user.id,
+      defenderId,
+      attacker?.username ?? "Raider",
+      defender?.username ?? "Island"
+    );
+    if (!res.ok || !res.report) {
+      await interaction.editReply({ content: res.message });
+      return;
+    }
+    await interaction.editReply({ embeds: [IslanderEmbeds.battleReport(res.report)] });
+  }
+
+  private async doScout(interaction: ButtonInteraction, defenderId: string) {
+    const [attacker, defender] = await Promise.all([
+      global.client.users.fetch(interaction.user.id).catch(() => null),
+      global.client.users.fetch(defenderId).catch(() => null),
+    ]);
+    const res = await CombatModule.scout(
+      interaction.user.id,
+      defenderId,
+      attacker?.username ?? "Scout",
+      defender?.username ?? "Island"
+    );
+    if (!res.ok || !res.intel) {
+      await interaction.reply({ content: res.message, ephemeral: true });
+      return;
+    }
+    await interaction.reply({ embeds: [IslanderEmbeds.scout(res.intel)], ephemeral: true });
   }
 }

--- a/interactionHandlers/buttons/islander.ts
+++ b/interactionHandlers/buttons/islander.ts
@@ -38,6 +38,13 @@ export default class IslanderButton implements IHandler {
         return;
       }
 
+      // Read-only / global actions — anyone may use them.
+      if (action === "leaderboard") return this.showLeaderboard(interaction);
+      if (action === "help") {
+        await interaction.reply({ embeds: [IslanderEmbeds.help()], ephemeral: true });
+        return;
+      }
+
       // Raid / scout act AGAINST ownerId (the target), so the attacker is the
       // clicker — these must run before the owner check below.
       if (action === "raid") return this.doRaid(interaction, ownerId);
@@ -209,6 +216,18 @@ export default class IslanderButton implements IHandler {
       return;
     }
     await interaction.editReply({ embeds: [IslanderEmbeds.battleReport(res.report)] });
+  }
+
+  private async showLeaderboard(interaction: ButtonInteraction) {
+    await interaction.deferReply({ ephemeral: true });
+    const top = await IslanderModule.leaderboard(10);
+    const entries = await Promise.all(
+      top.map(async (e) => {
+        const u = await global.client.users.fetch(e.id).catch(() => null);
+        return { name: u?.username ?? "Unknown", score: e.score, tc: e.tc };
+      })
+    );
+    await interaction.editReply({ embeds: [IslanderEmbeds.leaderboard(entries)] });
   }
 
   private async doScout(interaction: ButtonInteraction, defenderId: string) {

--- a/interactionHandlers/buttons/islander.ts
+++ b/interactionHandlers/buttons/islander.ts
@@ -2,6 +2,9 @@ import {
   ButtonInteraction,
   ActionRowBuilder,
   StringSelectMenuBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
 } from "discord.js";
 import { IHandler } from "../../interfaces/IHandler";
 import { IslanderView } from "../../islander/IslanderView";
@@ -62,6 +65,7 @@ export default class IslanderButton implements IHandler {
       if (action === "build") return this.openBuildSelect(interaction, ownerId);
       if (action === "upgrade") return this.openUpgradeSelect(interaction, ownerId);
       if (action === "train") return this.openTrainSelect(interaction, ownerId);
+      if (action === "exchange") return this.openExchangeModal(interaction, ownerId);
       if (action === "repair") {
         const res = await IslanderModule.repairWalls(ownerId);
         if (!res.ok) {
@@ -216,6 +220,27 @@ export default class IslanderButton implements IHandler {
       return;
     }
     await interaction.editReply({ embeds: [IslanderEmbeds.battleReport(res.report)] });
+  }
+
+  private async openExchangeModal(interaction: ButtonInteraction, ownerId: string) {
+    if (!IslanderModule.pointsExchangeEnabled) {
+      await interaction.reply({ content: "Points exchange is disabled.", ephemeral: true });
+      return;
+    }
+    const modal = new ModalBuilder()
+      .setCustomId(`islander_exchangeqty_${ownerId}`)
+      .setTitle("Exchange Points → Currency")
+      .addComponents(
+        new ActionRowBuilder<TextInputBuilder>().addComponents(
+          new TextInputBuilder()
+            .setCustomId("qty")
+            .setLabel("How many points to convert?")
+            .setStyle(TextInputStyle.Short)
+            .setPlaceholder("e.g. 50")
+            .setRequired(true)
+        )
+      );
+    await interaction.showModal(modal);
   }
 
   private async showLeaderboard(interaction: ButtonInteraction) {

--- a/interactionHandlers/modals/islander.ts
+++ b/interactionHandlers/modals/islander.ts
@@ -14,7 +14,7 @@ export default class IslanderModal implements IHandler {
     const [, kind, ownerId, unitKey] = interaction.customId.split("_");
 
     try {
-      if (kind !== "trainqty") return;
+      if (kind !== "trainqty" && kind !== "exchangeqty") return;
       if (interaction.user.id !== ownerId) {
         await interaction.reply({ content: "That's not your island.", ephemeral: true });
         return;
@@ -27,7 +27,10 @@ export default class IslanderModal implements IHandler {
         return;
       }
 
-      const res = await IslanderModule.trainUnit(ownerId, unitKey, qty);
+      const res =
+        kind === "exchangeqty"
+          ? await IslanderModule.exchangePoints(ownerId, qty)
+          : await IslanderModule.trainUnit(ownerId, unitKey, qty);
       await interaction.reply({ content: res.message, ephemeral: true });
     } catch (error) {
       log.error("Failed to handle islander train modal:", error);

--- a/islander/CombatModule.ts
+++ b/islander/CombatModule.ts
@@ -256,6 +256,14 @@ export abstract class CombatModule {
 
     log.info(`Raid ${attackerId} -> ${defenderId}: ${win ? "WIN" : "LOSS"}`);
 
+    // Notify the defender (respects their NotifyLevel opt-in).
+    const lootTotal = loot.Wood + loot.Stone + loot.Food + loot.Currency;
+    IslanderModule.notify(defenderId, {
+      content: win
+        ? `⚔️ Your island was **raided** by **${attackerName}** — they made off with loot (${lootTotal} resources) and damaged your walls. Open \`/island\` and \`Repair\`.`
+        : `🛡️ Your island was attacked by **${attackerName}**, but your defenders **held**! Open \`/island\` to check on your forces.`,
+    }).catch(() => {});
+
     return {
       ok: true,
       message: win ? "Raid successful!" : "Raid repelled!",

--- a/islander/CombatModule.ts
+++ b/islander/CombatModule.ts
@@ -256,6 +256,9 @@ export abstract class CombatModule {
 
     log.info(`Raid ${attackerId} -> ${defenderId}: ${win ? "WIN" : "LOSS"}`);
 
+    // Community-economy milestone hook (no-op unless ISLANDER_AWARD_POINTS).
+    if (win) IslanderModule.checkRaidMilestones(attackerId).catch(() => {});
+
     // Notify the defender (respects their NotifyLevel opt-in).
     const lootTotal = loot.Wood + loot.Stone + loot.Food + loot.Currency;
     IslanderModule.notify(defenderId, {

--- a/islander/CombatModule.ts
+++ b/islander/CombatModule.ts
@@ -1,0 +1,296 @@
+// PvP raiding resolution for Islander. See docs/ISLANDER_DESIGN.md §6 and
+// ISLANDER_BALANCE.md §9. Combat is instant and deterministic-with-jitter; the
+// result is persisted (casualties, loot, wall damage, shields, cooldowns) and
+// recorded in the i_Raid log.
+
+import {
+  UNITS,
+  PVP,
+  unitByName,
+  towerKillPct,
+  vaultPct,
+  vaultFloor,
+  navalCooldownReduction,
+  ResourceKey,
+} from "./data/balance";
+import { IslanderModule, IslandWithDetail } from "./IslanderModule";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger("CombatModule");
+
+const RESOURCES: ResourceKey[] = ["Currency", "Wood", "Stone", "Food"];
+
+export interface RaidResult {
+  ok: boolean;
+  message: string;
+  // present on a resolved raid (ok === true)
+  report?: {
+    attackerName: string;
+    defenderName: string;
+    win: boolean;
+    attackerLosses: Record<string, number>;
+    defenderLosses: Record<string, number>;
+    loot: Record<string, number>;
+    wallDamage: number;
+  };
+}
+
+export interface ScoutResult {
+  ok: boolean;
+  message: string;
+  intel?: {
+    name: string;
+    tcLevel: number;
+    estArmy: number; // estimated total units
+    estAttack: number;
+    wallHP: number;
+    towerLevel: number;
+  };
+}
+
+export abstract class CombatModule {
+  /** Pay Currency to estimate a target's defenses. */
+  static async scout(
+    attackerId: string,
+    defenderId: string,
+    attackerName: string,
+    defenderName: string
+  ): Promise<ScoutResult> {
+    if (attackerId === defenderId)
+      return { ok: false, message: "You can't scout your own island." };
+
+    const attacker = await IslanderModule.prepare(attackerId);
+    if (attacker.Currency < PVP.SCOUT_COST)
+      return { ok: false, message: `Scouting costs ${PVP.SCOUT_COST} 🪙 — you have ${attacker.Currency}.` };
+
+    const defender = await IslanderModule.prepare(defenderId);
+    await global.client.prisma.i_Island.update({
+      where: { ID: attackerId },
+      data: { Currency: attacker.Currency - PVP.SCOUT_COST },
+    });
+
+    const counts = IslanderModule.unitCounts(defender);
+    const estArmy = Object.values(counts).reduce((a, b) => a + b, 0);
+    // Add a little fuzz so intel is an estimate, not exact.
+    const fuzz = (n: number) => Math.round(n * (0.85 + Math.random() * 0.3));
+
+    return {
+      ok: true,
+      message: `Scouted ${defenderName} for ${PVP.SCOUT_COST} 🪙.`,
+      intel: {
+        name: defenderName,
+        tcLevel: IslanderModule.townCenterLevel(defender),
+        estArmy: fuzz(estArmy),
+        estAttack: fuzz(IslanderModule.armyAttack(defender)),
+        wallHP: IslanderModule.wallHPCurrent(defender),
+        towerLevel: IslanderModule.lineLevel(defender, "towers"),
+      },
+    };
+  }
+
+  /** Resolve a raid by attacker against defender. */
+  static async resolveRaid(
+    attackerId: string,
+    defenderId: string,
+    attackerName: string,
+    defenderName: string
+  ): Promise<RaidResult> {
+    if (attackerId === defenderId)
+      return { ok: false, message: "You can't raid your own island." };
+
+    const prisma = global.client.prisma;
+    const attacker = await IslanderModule.prepare(attackerId);
+    const defender = await IslanderModule.prepare(defenderId);
+
+    // ── Validations (§6.1, ISLANDER_BALANCE.md §9) ──
+    const now = Date.now();
+    if (attacker.RaidCooldown && new Date(attacker.RaidCooldown).getTime() > now)
+      return { ok: false, message: `Your raiders are still resting — ready ${IslanderModule.discordTime(new Date(attacker.RaidCooldown))}.` };
+
+    if (IslanderModule.lineLevel(attacker, "naval") < 1)
+      return { ok: false, message: "You need a Dock (Naval) and at least one ship to launch a raid." };
+
+    const attackerCounts = IslanderModule.unitCounts(attacker);
+    const attackerArmy = Object.values(attackerCounts).reduce((a, b) => a + b, 0);
+    const hasShip = UNITS.some((u) => u.type === 1 && (attackerCounts[u.key] ?? 0) > 0);
+    if (attackerArmy === 0) return { ok: false, message: "You have no units to raid with — train an army first." };
+    if (!hasShip) return { ok: false, message: "You need at least one ship (Longboat/Galley) to reach another island." };
+
+    const attackerTC = IslanderModule.townCenterLevel(attacker);
+    const defenderTC = IslanderModule.townCenterLevel(defender);
+    if (defenderTC < PVP.NEW_PLAYER_SHIELD_TC)
+      return { ok: false, message: `${defenderName} is under new-player protection (Town Center below ${PVP.NEW_PLAYER_SHIELD_TC}).` };
+    if (defender.ShieldUntil && new Date(defender.ShieldUntil).getTime() > now)
+      return { ok: false, message: `${defenderName} is shielded — raidable again ${IslanderModule.discordTime(new Date(defender.ShieldUntil))}.` };
+    if (Math.abs(attackerTC - defenderTC) > PVP.MATCHMAKING_BAND)
+      return { ok: false, message: `Target is out of range — Town Center must be within ±${PVP.MATCHMAKING_BAND} of yours (you ${attackerTC}, them ${defenderTC}).` };
+
+    const recent = await prisma.i_Raid.findFirst({
+      where: {
+        AttackerID: attackerId,
+        DefenderID: defenderId,
+        TimeStamp: { gt: new Date(now - PVP.REPEAT_TARGET_HOURS * 3_600_000) },
+      },
+    });
+    if (recent)
+      return { ok: false, message: `You've raided ${defenderName} recently — wait ${PVP.REPEAT_TARGET_HOURS}h between raids on the same island.` };
+
+    // ── Combat resolution (ISLANDER_BALANCE.md §9) ──
+    const atkSmith = 1 + IslanderModule.smithingBonus(attacker);
+    const defSmith = 1 + IslanderModule.smithingBonus(defender);
+    const killPct = towerKillPct(IslanderModule.lineLevel(defender, "towers"));
+    const wallHP = IslanderModule.wallHPCurrent(defender);
+
+    // Towers thin the attacking force before the clash.
+    let atkPower = 0;
+    for (const u of UNITS) {
+      const survivors = (attackerCounts[u.key] ?? 0) * (1 - killPct);
+      atkPower += survivors * u.attack;
+    }
+    atkPower *= atkSmith;
+
+    const defenderCounts = IslanderModule.unitCounts(defender);
+    let defPower = 0;
+    for (const u of UNITS) {
+      const c = defenderCounts[u.key] ?? 0;
+      defPower += c * (u.attack + 0.5 * u.hp);
+    }
+    defPower = defPower * defSmith + wallHP;
+
+    let ratio = atkPower / (atkPower + defPower || 1);
+    ratio *= 1 + (Math.random() * 2 - 1) * PVP.JITTER; // ±10% jitter
+    ratio = Math.max(0, Math.min(1, ratio));
+    const win = ratio > 0.5;
+
+    // Closer fights are bloodier; the loser takes the heavier toll.
+    const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+    const attackerLossFrac = Math.max(killPct, clamp(0.15 + (1 - ratio) * 0.7, 0.1, 0.9));
+    const defenderLossFrac = clamp(0.1 + ratio * 0.7, 0.05, 0.85);
+
+    const attackerLosses = await this.applyCasualties(attacker, attackerLossFrac);
+    const defenderLosses = await this.applyCasualties(defender, defenderLossFrac);
+
+    // Surviving attacker carry capacity.
+    let lootCapacity = 0;
+    for (const u of UNITS) {
+      const survivors = Math.max(0, (attackerCounts[u.key] ?? 0) - (attackerLosses[u.name] ?? 0));
+      lootCapacity += survivors * u.loot;
+    }
+
+    // Loot (only on a win), bounded by per-resource cap and total carry capacity.
+    const loot: Record<string, number> = { Wood: 0, Stone: 0, Food: 0, Currency: 0 };
+    const vPct = vaultPct(IslanderModule.lineLevel(defender, "keep"));
+    const vFloor = vaultFloor(IslanderModule.lineLevel(defender, "keep"));
+    if (win) {
+      let capacity = lootCapacity;
+      for (const res of RESOURCES) {
+        if (capacity <= 0) break;
+        const have = defender[res] as number;
+        const protectedAmt = Math.min(have, Math.max(vFloor, Math.floor(have * vPct)));
+        const unprotected = Math.max(0, have - protectedAmt);
+        const take = Math.min(Math.floor(unprotected * PVP.LOOT_PERCENT), capacity);
+        if (take > 0) {
+          loot[res] = take;
+          capacity -= take;
+        }
+      }
+    }
+
+    // Walls take damage from the assault.
+    const wallDamage = Math.min(wallHP, Math.round(atkPower * 0.4));
+
+    // ── Persist ──
+    const attackerCap = IslanderModule.storageCap(attacker);
+    await prisma.i_Island.update({
+      where: { ID: attackerId },
+      data: {
+        Wood: Math.min(attackerCap, attacker.Wood + loot.Wood),
+        Stone: Math.min(attackerCap, attacker.Stone + loot.Stone),
+        Food: Math.min(attackerCap, attacker.Food + loot.Food),
+        Currency: Math.min(attackerCap, attacker.Currency + loot.Currency),
+        RaidCooldown: new Date(
+          now +
+            PVP.RAID_COOLDOWN_HOURS *
+              3_600_000 *
+              (1 - navalCooldownReduction(IslanderModule.lineLevel(attacker, "naval")))
+        ),
+      },
+    });
+
+    await prisma.i_Island.update({
+      where: { ID: defenderId },
+      data: {
+        Wood: defender.Wood - loot.Wood,
+        Stone: defender.Stone - loot.Stone,
+        Food: defender.Food - loot.Food,
+        Currency: defender.Currency - loot.Currency,
+        // Post-raid shield only when the defender was actually beaten.
+        ShieldUntil: win
+          ? new Date(now + PVP.POST_RAID_SHIELD_HOURS * 3_600_000)
+          : defender.ShieldUntil,
+      },
+    });
+
+    if (wallDamage > 0) {
+      const wallsRow = IslanderModule.wallsRow(defender);
+      if (wallsRow) {
+        await prisma.i_Building_Island.update({
+          where: { BuildingID_IslandID: { BuildingID: wallsRow.BuildingID, IslandID: defenderId } },
+          data: { wallHP: Math.max(0, wallHP - wallDamage) },
+        });
+      }
+    }
+
+    await prisma.i_Raid.create({
+      data: {
+        AttackerID: attackerId,
+        DefenderID: defenderId,
+        AttackerWon: win,
+        LootWood: loot.Wood,
+        LootStone: loot.Stone,
+        LootFood: loot.Food,
+        LootCurrency: loot.Currency,
+        Report: JSON.stringify({ attackerLosses, defenderLosses, wallDamage, ratio: Number(ratio.toFixed(3)) }),
+      },
+    });
+
+    log.info(`Raid ${attackerId} -> ${defenderId}: ${win ? "WIN" : "LOSS"}`);
+
+    return {
+      ok: true,
+      message: win ? "Raid successful!" : "Raid repelled!",
+      report: { attackerName, defenderName, win, attackerLosses, defenderLosses, loot, wallDamage },
+    };
+  }
+
+  /**
+   * Apply a casualty fraction to an island's units, updating/deleting rows.
+   * Returns killed counts keyed by unit display name. Population isn't reduced —
+   * the survivors' lost comrades free up population for re-training.
+   */
+  private static async applyCasualties(
+    island: IslandWithDetail,
+    frac: number
+  ): Promise<Record<string, number>> {
+    const losses: Record<string, number> = {};
+    for (const row of island.Units ?? []) {
+      const name = row.i_Unit?.Name;
+      const killed = Math.floor(row.count * frac);
+      if (killed <= 0) continue;
+      const remaining = row.count - killed;
+      losses[name] = killed;
+      if (remaining > 0) {
+        await global.client.prisma.i_Unit_Island.update({
+          where: { IslandID_UnitID: { IslandID: island.ID, UnitID: row.UnitID } },
+          data: { count: remaining },
+        });
+      } else {
+        await global.client.prisma.i_Unit_Island.delete({
+          where: { IslandID_UnitID: { IslandID: island.ID, UnitID: row.UnitID } },
+        });
+      }
+      row.count = remaining;
+    }
+    return losses;
+  }
+}

--- a/islander/IslanderEmbeds.ts
+++ b/islander/IslanderEmbeds.ts
@@ -149,6 +149,65 @@ export abstract class IslanderEmbeds {
       .setTimestamp();
   }
 
+  /** Top-islands leaderboard. */
+  static leaderboard(
+    entries: { name: string; score: number; tc: number }[]
+  ): EmbedBuilder {
+    const medals = ["🥇", "🥈", "🥉"];
+    const body = entries.length
+      ? entries
+          .map(
+            (e, i) =>
+              `${medals[i] ?? `\`#${i + 1}\``} **${e.name}** — ${e.score} pts (TC ${e.tc})`
+          )
+          .join("\n")
+      : "No islands yet — be the first with `/island`!";
+    return new EmbedBuilder()
+      .setColor("#FD8612")
+      .setTitle("🏆 Islander Leaderboard")
+      .setDescription(body)
+      .setFooter({ text: "Power = 10·TC + 3·Σ building levels + army/10" })
+      .setTimestamp();
+  }
+
+  /** How-to-play tutorial. */
+  static help(): EmbedBuilder {
+    return new EmbedBuilder()
+      .setColor("#FD8612")
+      .setTitle("🏝️ How to play Islander")
+      .setDescription(
+        "Build an island, gather resources, raise an army, and raid your rivals!"
+      )
+      .addFields(
+        {
+          name: "Getting started",
+          value:
+            "`/island` opens your island. Resources (🪵🪨🍖🪙) accrue over time up to your storage cap — check back regularly. Your **Town Center** level gates everything else, so upgrade it first.",
+        },
+        {
+          name: "Build & upgrade",
+          value:
+            "Use the **Build** and **Upgrade** buttons. Only one build runs at a time; **Rush ⚡** finishes it instantly for 🪙. Warehouses raise storage, Housing grows population, Farms feed it.",
+        },
+        {
+          name: "Army",
+          value:
+            "Build an Army Camp (and a Dock for ships), then **Train 🪖**. Units occupy population and eat Food. Smithing boosts attack; you need a ship to raid.",
+        },
+        {
+          name: "Raiding",
+          value:
+            "Open someone else's island (`/island @member`) and press **Raid ⚔️** (or **Scout 🔭** first). Win to steal resources; the Castle/Keep **vault** and **walls** protect you on defense — **Repair 🧱** them after a hit.",
+        },
+        {
+          name: "Protection",
+          value:
+            "New islands (TC < 5) are safe, you get an 8h shield after being raided, and you can only be matched against islands within ±5 Town Center levels.",
+        }
+      )
+      .setFooter({ text: "Islander · FPG kraken bot" });
+  }
+
   /** Intel report shown after scouting a target. */
   static scout(intel: {
     name: string;

--- a/islander/IslanderEmbeds.ts
+++ b/islander/IslanderEmbeds.ts
@@ -109,4 +109,65 @@ export abstract class IslanderEmbeds {
 
     return embed;
   }
+
+  /** Post-battle report shown after a raid resolves. */
+  static battleReport(report: {
+    attackerName: string;
+    defenderName: string;
+    win: boolean;
+    attackerLosses: Record<string, number>;
+    defenderLosses: Record<string, number>;
+    loot: Record<string, number>;
+    wallDamage: number;
+  }): EmbedBuilder {
+    const fmtLosses = (l: Record<string, number>) => {
+      const e = Object.entries(l).filter(([, n]) => n > 0);
+      return e.length ? e.map(([n, c]) => `${n} ×${c}`).join(", ") : "none";
+    };
+    const lootLine = (["Wood", "Stone", "Food", "Currency"] as const)
+      .filter((r) => report.loot[r] > 0)
+      .map((r) => `${{ Wood: "🪵", Stone: "🪨", Food: "🍖", Currency: "🪙" }[r]} ${report.loot[r]}`)
+      .join("  ");
+
+    return new EmbedBuilder()
+      .setColor(report.win ? "#3ba55d" : "#ed4245")
+      .setTitle(report.win ? "⚔️ Raid successful!" : "🛡️ Raid repelled!")
+      .setDescription(
+        `**${report.attackerName}** raided **${report.defenderName}**.`
+      )
+      .addFields(
+        {
+          name: report.win ? "💰 Plunder" : "💰 Plunder",
+          value: report.win ? lootLine || "Nothing could be carried off." : "The defenders held — no loot.",
+          inline: false,
+        },
+        { name: `${report.attackerName} lost`, value: fmtLosses(report.attackerLosses), inline: true },
+        { name: `${report.defenderName} lost`, value: fmtLosses(report.defenderLosses), inline: true },
+        { name: "🧱 Wall damage", value: `${report.wallDamage}`, inline: true }
+      )
+      .setFooter({ text: "Islander · FPG kraken bot" })
+      .setTimestamp();
+  }
+
+  /** Intel report shown after scouting a target. */
+  static scout(intel: {
+    name: string;
+    tcLevel: number;
+    estArmy: number;
+    estAttack: number;
+    wallHP: number;
+    towerLevel: number;
+  }): EmbedBuilder {
+    return new EmbedBuilder()
+      .setColor("#5865f2")
+      .setTitle(`🔭 Scouting report — ${intel.name}`)
+      .setDescription("Estimates only — actual strength may vary.")
+      .addFields(
+        { name: "Town Center", value: `Lv ${intel.tcLevel}`, inline: true },
+        { name: "Army (est.)", value: `~${intel.estArmy} units · atk ~${intel.estAttack}`, inline: true },
+        { name: "Defenses", value: `🧱 ${intel.wallHP} wall HP · 🗼 towers Lv ${intel.towerLevel}`, inline: false }
+      )
+      .setFooter({ text: "Islander · FPG kraken bot" })
+      .setTimestamp();
+  }
 }

--- a/islander/IslanderModule.ts
+++ b/islander/IslanderModule.ts
@@ -20,6 +20,7 @@ import {
   ResourceKey,
 } from "./data/balance";
 import { IslanderSeed } from "./IslanderSeed";
+import { EventNotification } from "../modules/NotificationLevels";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("IslanderModule");
@@ -419,6 +420,7 @@ export abstract class IslanderModule {
         wallHP: 0,
       },
     });
+    this.scheduleBuildComplete(userId, seconds * 1000, line.tierNames[0]);
     return this.ok(`🏗️ Building **${line.tierNames[0]}** — ready ${this.discordTime(ready)}.`);
   }
 
@@ -454,6 +456,7 @@ export abstract class IslanderModule {
       where: { BuildingID_IslandID: { BuildingID: b.BuildingID, IslandID: userId } },
       data: { upgrading: next, upgradeReady: ready },
     });
+    this.scheduleBuildComplete(userId, seconds * 1000, tierNameFor(line, next));
     return this.ok(
       `⏫ Upgrading **${tierNameFor(line, level)}** → **${tierNameFor(line, next)}** (Lv ${next}) — ready ${this.discordTime(ready)}.`
     );
@@ -652,6 +655,66 @@ export abstract class IslanderModule {
       data: { wallHP: max },
     });
     return this.ok(`🧱 Repaired walls to full (${max} HP) for ${cost} 🪨.`);
+  }
+
+  // ── Notifications ───────────────────────────────────────────────────────────
+
+  /** DM a member an Islander event, if they've opted into notifications. */
+  static async notify(userId: string, payload: any): Promise<void> {
+    try {
+      const m = await global.client.prisma.members.findUnique({
+        where: { ID: userId },
+        select: { NotifyLevel: true },
+      });
+      if (!m || ((m.NotifyLevel ?? 0) & EventNotification) === 0) return;
+      const user = await global.client.users.fetch(userId).catch(() => null);
+      await user?.send(payload).catch(() => {});
+    } catch (error) {
+      log.error("Failed to send islander notification:", error);
+    }
+  }
+
+  /** Best-effort DM when a build finishes (in-memory timer; lost on restart). */
+  static scheduleBuildComplete(userId: string, ms: number, label: string): void {
+    if (ms <= 0 || ms >= 2_147_483_647) return; // setTimeout 32-bit limit (~24.8d)
+    setTimeout(() => {
+      this.notify(userId, {
+        content: `🏝️ Your **${label}** has finished building! Open \`/island\` to see it.`,
+      }).catch(() => {});
+    }, ms);
+  }
+
+  // ── Leaderboard ─────────────────────────────────────────────────────────────
+
+  /** Power score for ranking (docs/ISLANDER_DESIGN.md §8 / §10). */
+  static powerScore(island: IslandWithDetail): number {
+    const tc = this.townCenterLevel(island);
+    let buildingSum = 0;
+    for (const b of island.Buildings ?? []) buildingSum += this.effectiveLevel(b);
+    const counts = this.unitCounts(island);
+    let armyVal = 0;
+    for (const u of UNITS) armyVal += (counts[u.key] ?? 0) * (u.attack + u.hp);
+    return Math.round(10 * tc + 3 * buildingSum + armyVal / 10);
+  }
+
+  /** Top islands by power score. */
+  static async leaderboard(
+    limit = 10
+  ): Promise<{ id: string; score: number; tc: number }[]> {
+    const islands = await global.client.prisma.i_Island.findMany({
+      include: {
+        Buildings: { include: { i_Building: true } },
+        Units: { include: { i_Unit: true } },
+      },
+    });
+    return islands
+      .map((i: any) => ({
+        id: i.ID,
+        score: this.powerScore(i),
+        tc: this.townCenterLevel(i),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
   }
 
   // ── small helpers ──────────────────────────────────────────────────────────

--- a/islander/IslanderModule.ts
+++ b/islander/IslanderModule.ts
@@ -9,6 +9,9 @@ import {
   BUILDING_LINES,
   UNITS,
   PVP,
+  INTEGRATIONS,
+  MILESTONES,
+  Milestone,
   lineByKey,
   levelStats,
   tcRequirement,
@@ -315,6 +318,7 @@ export abstract class IslanderModule {
     };
   }> {
     const island = await this.prepare(userId);
+    await this.checkTcMilestones(userId, island); // no-op unless integrations enabled
     return {
       island,
       cap: this.storageCap(island),
@@ -715,6 +719,117 @@ export abstract class IslanderModule {
       }))
       .sort((a, b) => b.score - a.score)
       .slice(0, limit);
+  }
+
+  // ── Phase 5: community-economy integrations (feature-flagged, off by default) ─
+
+  /** Award community Points for Islander milestones? (env ISLANDER_AWARD_POINTS) */
+  static get pointsAwardEnabled(): boolean {
+    return process.env.ISLANDER_AWARD_POINTS === "true";
+  }
+
+  /** Allow converting community Points → island Currency? (env ISLANDER_POINTS_EXCHANGE) */
+  static get pointsExchangeEnabled(): boolean {
+    return process.env.ISLANDER_POINTS_EXCHANGE === "true";
+  }
+
+  /** Award a milestone's Points once (idempotent via a PointHistory marker). */
+  static async awardMilestone(userId: string, m: Milestone): Promise<boolean> {
+    const prisma = global.client.prisma;
+    const marker = `ISL:milestone:${m.key}`;
+    const already = await prisma.pointHistory.findFirst({
+      where: { userid: userId, comment: { startsWith: marker } },
+    });
+    if (already) return false;
+
+    await prisma.points.upsert({
+      where: { userid: userId },
+      update: { TotalPoints: { increment: m.points }, lastComment: m.label },
+      create: { userid: userId, TotalPoints: m.points, lastComment: m.label },
+    });
+    await prisma.pointHistory.create({
+      data: { userid: userId, points: m.points, comment: `${marker} ${m.label}` },
+    });
+    this.notify(userId, {
+      content: `🏝️ **Islander milestone:** ${m.label} — +${m.points} :palm_tree: points!`,
+    }).catch(() => {});
+    return true;
+  }
+
+  /** Check Town-Center milestones for an island (no-op unless enabled). */
+  static async checkTcMilestones(userId: string, island: IslandWithDetail): Promise<void> {
+    if (!this.pointsAwardEnabled) return;
+    const tc = this.townCenterLevel(island);
+    for (const m of MILESTONES) {
+      if (m.type === "tc" && tc >= m.threshold) {
+        await this.awardMilestone(userId, m).catch((e) =>
+          log.error("milestone award failed:", e)
+        );
+      }
+    }
+  }
+
+  /** Check raid-win milestones (called after a winning raid; no-op unless enabled). */
+  static async checkRaidMilestones(userId: string): Promise<void> {
+    if (!this.pointsAwardEnabled) return;
+    const wins = await global.client.prisma.i_Raid.count({
+      where: { AttackerID: userId, AttackerWon: true },
+    });
+    for (const m of MILESTONES) {
+      if (m.type === "raidwins" && wins >= m.threshold) {
+        await this.awardMilestone(userId, m).catch((e) =>
+          log.error("milestone award failed:", e)
+        );
+      }
+    }
+  }
+
+  /** Convert community Points into island Currency (rate-limited, capped). */
+  static async exchangePoints(userId: string, points: number) {
+    if (!this.pointsExchangeEnabled)
+      return this.fail("Points exchange is currently disabled.");
+    if (!Number.isFinite(points) || points < 1)
+      return this.fail("Enter a whole number of points (1 or more).");
+    points = Math.floor(points);
+
+    const prisma = global.client.prisma;
+    const pts = await prisma.points.findUnique({ where: { userid: userId } });
+    const balance = pts?.TotalPoints ?? 0;
+    if (balance < points)
+      return this.fail(`You only have ${balance} :palm_tree: points.`);
+
+    // Daily cap across all conversions today.
+    const since = new Date();
+    since.setHours(0, 0, 0, 0);
+    const agg = await prisma.pointHistory.aggregate({
+      _sum: { points: true },
+      where: { userid: userId, TimeStamp: { gte: since }, comment: { startsWith: "ISL:exchange" } },
+    });
+    const spentToday = -(agg._sum.points ?? 0);
+    const remaining = INTEGRATIONS.EXCHANGE_DAILY_POINT_CAP - spentToday;
+    if (points > remaining)
+      return this.fail(`Daily exchange cap is ${INTEGRATIONS.EXCHANGE_DAILY_POINT_CAP} points — you can convert ${Math.max(0, remaining)} more today.`);
+
+    const island = await this.prepare(userId);
+    const gain = points * INTEGRATIONS.POINTS_PER_CURRENCY;
+    const cap = this.storageCap(island);
+    const newCurrency = Math.min(cap, island.Currency + gain);
+    const actuallyGained = newCurrency - island.Currency;
+
+    await prisma.points.update({
+      where: { userid: userId },
+      data: { TotalPoints: { decrement: points }, lastComment: "Islander currency exchange" },
+    });
+    await prisma.pointHistory.create({
+      data: { userid: userId, points: -points, comment: `ISL:exchange ${points} pts → ${gain} 🪙` },
+    });
+    await prisma.i_Island.update({ where: { ID: userId }, data: { Currency: newCurrency } });
+
+    const wasted = gain - actuallyGained;
+    return this.ok(
+      `🔁 Converted **${points}** :palm_tree: → **${actuallyGained}** 🪙` +
+        (wasted > 0 ? ` (${wasted} lost to your storage cap)` : "") + "."
+    );
   }
 
   // ── small helpers ──────────────────────────────────────────────────────────

--- a/islander/IslanderModule.ts
+++ b/islander/IslanderModule.ts
@@ -8,6 +8,7 @@ import {
   CONSTANTS,
   BUILDING_LINES,
   UNITS,
+  PVP,
   lineByKey,
   levelStats,
   tcRequirement,
@@ -605,6 +606,52 @@ export abstract class IslanderModule {
     });
 
     return this.ok(`🪖 Trained **${qty}× ${def.name}**.`);
+  }
+
+  // ── Walls / defense ─────────────────────────────────────────────────────────
+
+  /** The walls building row (holds current wallHP), or null. */
+  static wallsRow(island: IslandWithDetail): any | null {
+    return (island.Buildings ?? []).find(
+      (b: any) => b.i_Building?.Name === "walls"
+    ) ?? null;
+  }
+
+  /** Maximum wall HP at the walls building's current level (0 if none). */
+  static wallHPMax(island: IslandWithDetail): number {
+    const line = lineByKey("walls");
+    const lvl = this.lineLevel(island, "walls");
+    return line && lvl > 0 ? levelStats(line, lvl).attr : 0;
+  }
+
+  /** Current standing wall HP (depleted by raids, restored by /repair). */
+  static wallHPCurrent(island: IslandWithDetail): number {
+    const row = this.wallsRow(island);
+    return row?.wallHP ?? 0;
+  }
+
+  /** Restore walls to full HP, paying Stone (1 Stone per 4 HP). */
+  static async repairWalls(userId: string) {
+    const island = await this.prepare(userId);
+    const row = this.wallsRow(island);
+    if (!row) return this.fail("You have no walls to repair.");
+    const max = this.wallHPMax(island);
+    const missing = Math.max(0, max - (row.wallHP ?? 0));
+    if (missing <= 0) return this.fail("Your walls are already at full strength.");
+
+    const cost = Math.ceil(missing * PVP.STONE_PER_WALL_HP);
+    if (island.Stone < cost)
+      return this.fail(`Repairing ${missing} wall HP costs ${cost} 🪨 — you have ${island.Stone}.`);
+
+    await global.client.prisma.i_Island.update({
+      where: { ID: userId },
+      data: { Stone: island.Stone - cost },
+    });
+    await global.client.prisma.i_Building_Island.update({
+      where: { BuildingID_IslandID: { BuildingID: row.BuildingID, IslandID: userId } },
+      data: { wallHP: max },
+    });
+    return this.ok(`🧱 Repaired walls to full (${max} HP) for ${cost} 🪨.`);
   }
 
   // ── small helpers ──────────────────────────────────────────────────────────

--- a/islander/IslanderView.ts
+++ b/islander/IslanderView.ts
@@ -81,6 +81,15 @@ export abstract class IslanderView {
           .setStyle(ButtonStyle.Secondary)
           .setDisabled(!wallsDamaged)
       );
+      // Optional Points → Currency exchange (Phase 5, off unless enabled).
+      if (IslanderModule.pointsExchangeEnabled) {
+        row2.addComponents(
+          new ButtonBuilder()
+            .setCustomId(`islander_exchange_${targetId}`)
+            .setLabel("Exchange 🔁")
+            .setStyle(ButtonStyle.Secondary)
+        );
+      }
     } else {
       // Someone else's island: scout or raid it.
       row2.addComponents(

--- a/islander/IslanderView.ts
+++ b/islander/IslanderView.ts
@@ -95,6 +95,18 @@ export abstract class IslanderView {
       );
     }
 
-    return { embeds: [embed], files: [image], components: [row1, row2] };
+    // Always-available info actions.
+    const row3 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`islander_leaderboard_${targetId}`)
+        .setLabel("Leaderboard 🏆")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(`islander_help_${targetId}`)
+        .setLabel("How to play ❓")
+        .setStyle(ButtonStyle.Secondary)
+    );
+
+    return { embeds: [embed], files: [image], components: [row1, row2, row3] };
   }
 }

--- a/islander/IslanderView.ts
+++ b/islander/IslanderView.ts
@@ -64,18 +64,36 @@ export abstract class IslanderView {
         .setDisabled(!isOwner || !building)
     );
 
-    const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`islander_train_${targetId}`)
-        .setLabel("Train 🪖")
-        .setStyle(ButtonStyle.Success)
-        .setDisabled(!isOwner),
-      new ButtonBuilder()
-        .setCustomId("islander_raid_disabled")
-        .setLabel("Raid")
-        .setStyle(ButtonStyle.Danger)
-        .setDisabled(true) // Phase 3
-    );
+    const row2 = new ActionRowBuilder<ButtonBuilder>();
+    if (isOwner) {
+      // Own island: train units and repair damaged walls.
+      const wallsDamaged =
+        IslanderModule.wallHPCurrent(view.island) <
+        IslanderModule.wallHPMax(view.island);
+      row2.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`islander_train_${targetId}`)
+          .setLabel("Train 🪖")
+          .setStyle(ButtonStyle.Success),
+        new ButtonBuilder()
+          .setCustomId(`islander_repair_${targetId}`)
+          .setLabel("Repair 🧱")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(!wallsDamaged)
+      );
+    } else {
+      // Someone else's island: scout or raid it.
+      row2.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`islander_scout_${targetId}`)
+          .setLabel("Scout 🔭")
+          .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId(`islander_raid_${targetId}`)
+          .setLabel("Raid ⚔️")
+          .setStyle(ButtonStyle.Danger)
+      );
+    }
 
     return { embeds: [embed], files: [image], components: [row1, row2] };
   }

--- a/islander/data/balance.ts
+++ b/islander/data/balance.ts
@@ -261,3 +261,30 @@ export function vaultFloor(level: number): number {
 export function navalCooldownReduction(level: number): number {
   return Math.min(0.4, 0.02 * level);
 }
+
+// ── Phase 5: community-economy integrations (off by default) ─────────────────
+// Enabled per-flag via env vars; see docs/ISLANDER_DESIGN.md §10.
+
+export const INTEGRATIONS = {
+  POINTS_PER_CURRENCY: 10, // 1 community Point → this much island Currency
+  EXCHANGE_DAILY_POINT_CAP: 100, // max Points a player may convert per day
+};
+
+export interface Milestone {
+  key: string;
+  type: "tc" | "raidwins";
+  threshold: number;
+  points: number; // one-way community Points award
+  label: string;
+}
+
+// One-way Point rewards for Islander achievements. Modest by design so they
+// don't inflate the community economy.
+export const MILESTONES: Milestone[] = [
+  { key: "tc5", type: "tc", threshold: 5, points: 25, label: "Reached Town Center level 5" },
+  { key: "tc10", type: "tc", threshold: 10, points: 75, label: "Reached Town Center level 10" },
+  { key: "tc20", type: "tc", threshold: 20, points: 200, label: "Reached Town Center level 20" },
+  { key: "raid1", type: "raidwins", threshold: 1, points: 40, label: "Won your first raid" },
+  { key: "raid10", type: "raidwins", threshold: 10, points: 150, label: "Won 10 raids" },
+  { key: "raid50", type: "raidwins", threshold: 50, points: 500, label: "Won 50 raids" },
+];

--- a/islander/data/balance.ts
+++ b/islander/data/balance.ts
@@ -225,3 +225,39 @@ export function levelStats(line: BuildingLine, level: number): LevelStats {
 export function lineByKey(key: string): BuildingLine | undefined {
   return BUILDING_LINES.find((l) => l.key === key);
 }
+
+// ── PvP raiding (docs/ISLANDER_DESIGN.md §6, ISLANDER_BALANCE.md §9) ──────────
+
+export const PVP = {
+  LOOT_PERCENT: 0.2, // max % of a resource's *unprotected* amount a raid takes
+  NEW_PLAYER_SHIELD_TC: 5, // islands below this Town Center level can't be raided
+  POST_RAID_SHIELD_HOURS: 8, // protection after being successfully raided
+  RAID_COOLDOWN_HOURS: 4, // base attacker cooldown (reduced by Naval)
+  REPEAT_TARGET_HOURS: 24, // can't re-raid the same victim within this window
+  MATCHMAKING_BAND: 5, // target TC must be within ±this of the attacker's
+  SCOUT_COST: 50, // Currency to scout a target's defenses
+  TOWER_KILL_CAP: 0.25, // max fraction of attackers towers kill pre-battle
+  WALL_DR_CAP: 0.45, // (reference) max wall damage reduction
+  JITTER: 0.1, // ±10% randomness on the power ratio
+  STONE_PER_WALL_HP: 0.25, // /repair cost: 1 Stone restores 4 HP
+};
+
+/** Fraction of attacking units killed before the clash by defender towers. */
+export function towerKillPct(level: number): number {
+  return level > 0 ? Math.min(PVP.TOWER_KILL_CAP, 0.02 * level) : 0;
+}
+
+/** Fraction of each resource the Castle/Keep vault protects from raids. */
+export function vaultPct(level: number): number {
+  return level > 0 ? Math.min(0.55, 0.15 + 0.0285 * (level - 1)) : 0;
+}
+
+/** Flat per-resource amount the vault protects regardless of percentage. */
+export function vaultFloor(level: number): number {
+  return level > 0 ? level * 2000 : 0;
+}
+
+/** Attacker raid-cooldown reduction from the Naval line (max 40%). */
+export function navalCooldownReduction(level: number): number {
+  return Math.min(0.4, 0.02 * level);
+}


### PR DESCRIPTION
Builds on the merged Islander foundations (#93, Phases 0–2). Everything is button/menu-driven from `/island` — no new slash commands.

## Phase 3 — PvP raiding (`islander/CombatModule.ts`)
- **Raid ⚔️ / Scout 🔭** buttons on another member's island; **Repair 🧱** on your own.
- Validations: ship requirement (Naval ≥ 1), new-player shield (TC < 5), post-raid shield, attacker cooldown (Naval-reduced), ±5 TC matchmaking band, 24h repeat-target guard, no self-raids.
- Combat: tower pre-kill → Smithing-boosted attacker power vs defender power (unit attack + ½ HP + wall HP) with ±10% jitter → casualties both sides.
- Loot bounded by `LOOT_PERCENT` (20%), the Castle/Keep **vault** (% + floor), and surviving carry capacity; clamped to attacker storage.
- Wall damage + `Repair` (Stone per HP), `i_Raid` log, battle-report embed.

## Phase 4 — Polish & social
- **Leaderboard 🏆** (power-score ranking) and **How to play ❓** tutorial buttons.
- Notifications (opt-in via `NotifyLevel`): raid DM at event time; best-effort build-complete DM.
- `docs/ISLANDER_TESTING.md` — full manual test plan for Phases 0–5.

## Phase 5 — Economy integrations (feature-flagged, **off by default**)
- `ISLANDER_AWARD_POINTS` — one-way milestone Point awards (TC 5/10/20, 1/10/50 raid wins), idempotent via `PointHistory` markers.
- `ISLANDER_POINTS_EXCHANGE` — **Exchange 🔁** Points→Currency (10:1, 100/day cap, storage-clamped).
- Shop/skins deferred to post-Phase-6 (needs real art).

## Notes
- **No new migration** — `i_Raid`, `ShieldUntil`, `RaidCooldown` shipped in Phase 0; Phase 5 reuses `Points`/`PointHistory`.
- `npm run build` is clean; pure logic (combat tuning, power score, flags) verified locally.
- **Not exercised against a live DB/Discord** in CI — please run through `docs/ISLANDER_TESTING.md` on a server.
- Docs updated: `ISLANDER_DESIGN.md` (Phases 3–5 ✅), `CLAUDE.md` (CombatModule + env flags).

https://claude.ai/code/session_01RLGerwLYHAtQnhtwcnurD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLGerwLYHAtQnhtwcnurD2)_