### PR TITLE
Fix raid votes button to use raidId from customId

### DIFF
--- a/interactionHandlers/buttons/raidVotes.ts
+++ b/interactionHandlers/buttons/raidVotes.ts
@@ -2,7 +2,6 @@ import { RaidModule } from "../../modules/RaidModule";
 import {
   ButtonInteraction,
   InteractionEditReplyOptions,
-  Message,
 } from "discord.js";
 import { IHandler } from "../../interfaces/IHandler";
 
@@ -11,11 +10,14 @@ export default class RaidVotesHandler implements IHandler {
 
   async execute(interaction: ButtonInteraction): Promise<void> {
     await interaction.deferReply({ ephemeral: true });
-    const message: Message = await interaction.channel.messages.fetch(
-      interaction.message.id
-    );
-    const content = message.content;
-    const embed = await RaidModule.showVotes(Number(content));
+    const raidId = Number(interaction.customId.split("_")[1]);
+    const embed = await RaidModule.showVotes(raidId);
+    if (!embed) {
+      await interaction.editReply({
+        content: "Sorry, I couldn't find this raid's scheduling votes.",
+      } as InteractionEditReplyOptions);
+      return;
+    }
     await interaction.editReply({
       embeds: [embed],
       ephemeral: true,

--- a/modules/RaidEmbeds.ts
+++ b/modules/RaidEmbeds.ts
@@ -125,7 +125,7 @@ export abstract class RaidEmbeds {
   static buildSchedulingActionRow(raidId: number) {
     return new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
-        .setCustomId("raidVotes")
+        .setCustomId(`raidVotes_${raidId}`)
         .setLabel("View Participants' Chosen Times")
         .setStyle(ButtonStyle.Secondary),
       new ButtonBuilder()

--- a/modules/RaidModule.ts
+++ b/modules/RaidModule.ts
@@ -53,6 +53,9 @@ export abstract class RaidModule {
       },
       where: { ID: raidId },
     });
+    if (raid == null) {
+      return null;
+    }
     let votes = await RaidScheduler.CollectSchedulingVotes(raid);
 
     let embed = new EmbedBuilder()


### PR DESCRIPTION
## Summary
Refactored the raid votes button handler to extract the raid ID from the button's custom ID instead of fetching the message and parsing its content. This improves reliability and eliminates an unnecessary message fetch.

## Key Changes
- **raidVotes.ts**: Changed button handler to extract `raidId` from `interaction.customId` (format: `raidVotes_{raidId}`) instead of fetching the message and parsing its content
- **raidVotes.ts**: Added null check for the embed returned by `RaidModule.showVotes()` with user-friendly error message
- **RaidModule.ts**: Added null check in `showVotes()` to return `null` if the raid is not found, allowing the handler to gracefully handle missing raids
- **RaidEmbeds.ts**: Updated `buildSchedulingActionRow()` to include the raid ID in the button's custom ID (`raidVotes_${raidId}`)

## Implementation Details
- The custom ID now encodes the raid ID directly, eliminating the need to fetch and parse the message content
- Error handling is now consistent: if a raid is deleted or not found, users receive a clear error message instead of a silent failure
- This change makes the button interaction more resilient to message content changes

https://claude.ai/code/session_01G8Nq3nrUTZtpb2yF4EnHaK