### PR TITLE
Fix raid custom-time scheduling: avoid 10062 and re-send voting DMs

### DIFF
--- a/interactionHandlers/modals/raidCustomTimeSubmit.ts
+++ b/interactionHandlers/modals/raidCustomTimeSubmit.ts
@@ -53,8 +53,12 @@ export default class RaidCustomTimeSubmitHandler implements IHandler {
     try {
       await RaidScheduler.AddSingleSchedulingOptionToRaid(raidId, parsed.toDate());
 
+      // Re-send the scheduling DM to every participant so the new option shows
+      // up in their voting menu — Discord won't update already-sent select menus.
+      await RaidScheduler.SendSchedulingDMs(raidId);
+
       await interaction.editReply({
-        content: `Successfully added <t:${parsed.unix()}:F> to the raid options! Participants will see it next time they open the voting menu.`,
+        content: `Successfully added <t:${parsed.unix()}:F> to the raid options! Participants have been sent an updated voting menu in their DMs.`,
       });
 
       // Notify in LFG

--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -114,6 +114,40 @@ export abstract class RaidScheduler {
       log.warn("Raid not found for scheduling message: " + raidId);
       return;
     }
+
+    await this.SendSchedulingDMs(raidId);
+
+    let participants = "";
+    raid.RaidAttendees.forEach((attendee) => {
+      participants += "<@" + attendee.MemberId + ">\n";
+    });
+
+    let updateEmbed = new EmbedBuilder()
+      .setTitle("Raid has entered scheduling: " + raid.Title)
+      .setDescription("Participants: \n" + participants)
+      .setFooter({
+        text: "Scheduling closes ",
+        iconURL:
+          "https://flamingpalm.com/assets/images/logo/FlamingPalmLogoSmall.png",
+      })
+      .setColor("#0099ff");
+    global.client.lfg
+      .send({ embeds: [updateEmbed] })
+      .catch((err) => log.error("Failed to send scheduling update to lfg:", err));
+  }
+
+  /**
+   * (Re)sends the scheduling DM — embed + fresh select menu of all current
+   * options — to every attendee of a raid. Used both when scheduling first
+   * opens and when a new option (e.g. a custom suggested time) is added, since
+   * Discord does not retroactively update select menus in already-sent DMs.
+   */
+  static async SendSchedulingDMs(raidId: number) {
+    let raid = await this.getRaid(raidId);
+    if (raid == null) {
+      log.warn("Raid not found for scheduling DMs: " + raidId);
+      return;
+    }
     let embed = RaidEmbeds.buildSchedulingMessage(raid);
     let row = RaidEmbeds.buildSchedulingActionRow(raid.ID);
     let selectMenu = RaidEmbeds.buildSchedulingSelectMenu(raid.ID, raid.RaidSchedulingOption);
@@ -148,24 +182,6 @@ export abstract class RaidScheduler {
           )
         );
     });
-
-    let participants = "";
-    raid.RaidAttendees.forEach((attendee) => {
-      participants += "<@" + attendee.MemberId + ">\n";
-    });
-
-    let updateEmbed = new EmbedBuilder()
-      .setTitle("Raid has entered scheduling: " + raid.Title)
-      .setDescription("Participants: \n" + participants)
-      .setFooter({
-        text: "Scheduling closes ",
-        iconURL:
-          "https://flamingpalm.com/assets/images/logo/FlamingPalmLogoSmall.png",
-      })
-      .setColor("#0099ff");
-    global.client.lfg
-      .send({ embeds: [updateEmbed] })
-      .catch((err) => log.error("Failed to send scheduling update to lfg:", err));
   }
 
   static async resendRaid(raidID: number, user: User) {


### PR DESCRIPTION
## Summary

Fixes two related bugs in the raid custom-time scheduling flow.

### 1. `DiscordAPIError[10062] Unknown interaction` on submit
`raidCustomTimeSubmit` called `TimeParser.parse()` before acknowledging the interaction. `TimeParser.parse()` can fall back to a slow AI call that exceeds Discord's 3-second interaction window, invalidating the modal token before `reply()`.

**Fix:** `deferReply({ ephemeral: true })` immediately (before the slow parse), and switch the subsequent `reply` calls to `editReply`.

### 2. Participants never got an updated voting menu
`AddSingleSchedulingOptionToRaid` only inserted the new option into the DB. Participants' already-sent scheduling DMs contain a static Discord select menu that Discord won't retroactively update — so the new time never appeared and nobody could vote for it, despite the LFG message telling them to check their DMs.

**Fix:** Extracted the DM-sending logic from `SendSchedulingMessage` into a reusable `RaidScheduler.SendSchedulingDMs(raidId)`, and call it after adding a custom time so every participant receives a fresh voting menu including the new option. Existing votes persist (they live in `RaidAvailability`, keyed by option).

## Notes
- This re-DMs every participant each time a custom time is suggested. That matches the intent of the existing LFG "check your DMs" message; can debounce later if it proves spammy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012VDHydU2t2UzHmivBw2f23)_