### PR TITLE
Handle legacy raidVotes buttons without an ID suffix

### DIFF
--- a/interactionHandlers/buttons/raidVotes.ts
+++ b/interactionHandlers/buttons/raidVotes.ts
@@ -10,8 +10,15 @@ export default class RaidVotesHandler implements IHandler {
 
   async execute(interaction: ButtonInteraction): Promise<void> {
     await interaction.deferReply({ ephemeral: true });
-    const raidId = Number(interaction.customId.split("_")[1]);
-    const embed = await RaidModule.showVotes(raidId);
+    let raidId = Number(interaction.customId.split("_")[1]);
+    // Older scheduling messages used a static "raidVotes" customId without the
+    // raid ID. Recover it from the sibling vote select menu (raidVote_<id>).
+    if (isNaN(raidId)) {
+      raidId = this.findRaidIdFromComponents(interaction);
+    }
+    const embed = isNaN(raidId)
+      ? null
+      : await RaidModule.showVotes(raidId);
     if (!embed) {
       await interaction.editReply({
         content: "Sorry, I couldn't find this raid's scheduling votes.",
@@ -22,5 +29,19 @@ export default class RaidVotesHandler implements IHandler {
       embeds: [embed],
       ephemeral: true,
     } as InteractionEditReplyOptions);
+  }
+
+  // Scans the message's components for the vote select menu (customId
+  // "raidVote_<id>") and extracts the raid ID. Returns NaN if not found.
+  private findRaidIdFromComponents(interaction: ButtonInteraction): number {
+    for (const row of interaction.message.components ?? []) {
+      for (const component of (row as any).components ?? []) {
+        const customId: string | undefined = component.customId;
+        if (customId && customId.startsWith("raidVote_")) {
+          return Number(customId.split("_")[1]);
+        }
+      }
+    }
+    return NaN;
   }
 }


### PR DESCRIPTION
## Problem

After PR #103, pressing **"View Participants' Chosen Times"** on scheduling DMs sent *before* that fix raised:

```
Error: Argument ID: Got invalid value NaN on prisma.findFirstRaids.
```

Those older messages still carry the original static `raidVotes` customId (no raid ID), so `customId.split("_")[1]` is `undefined`, `Number(undefined)` is `NaN`, and Prisma rejects `ID: NaN` before the `null` guard from #103 can run.

## Fix

In `interactionHandlers/buttons/raidVotes.ts`:
- Guard against `NaN` so an invalid ID never reaches Prisma.
- When the button customId lacks the ID (legacy messages), recover it from the sibling vote select menu (`raidVote_<id>`) in the same message — so existing scheduling DMs keep working without needing a fresh message.
- Falls back to the friendly "couldn't find this raid's votes" reply only if no ID can be found.

New messages use `raidVotes_<id>` directly; old ones fall back to the select menu — both paths covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8Nq3nrUTZtpb2yF4EnHaK

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8Nq3nrUTZtpb2yF4EnHaK)_