### PR TITLE
Prevent duplicate raid scheduling options via unique constraint

### DIFF
--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -90,6 +90,25 @@ export abstract class RaidScheduler {
   }
 
   static async AddSingleSchedulingOptionToRaid(raidId: number, timestamp: Date) {
+    // Guard against duplicates: if this raid already has an option at the exact
+    // same time, return it instead of creating a second identical row. Without
+    // this, a double-submit (retry after an error, double-click, or suggesting
+    // a time that already exists) creates duplicate "No votes" entries.
+    const existing =
+      await global.client.prisma.raidSchedulingOption.findFirst({
+        where: { RaidId: raidId, Timestamp: timestamp },
+      });
+    if (existing) {
+      log.info(
+        "Scheduling option already exists for raid " +
+          raidId +
+          " at " +
+          timestamp.toISOString() +
+          "; skipping duplicate"
+      );
+      return existing;
+    }
+
     const lastSchedulingOption =
       await global.client.prisma.raidSchedulingOption.findFirst({
         where: { RaidId: raidId },

--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -118,13 +118,33 @@ export abstract class RaidScheduler {
     let lastOption = lastSchedulingOption ? lastSchedulingOption.Option : "@"; // '@' is ASCII before 'A'
     let nextOption = String.fromCharCode(lastOption.charCodeAt(0) + 1);
 
-    return global.client.prisma.raidSchedulingOption.create({
-      data: {
-        RaidId: raidId,
-        Timestamp: timestamp,
-        Option: nextOption,
-      },
-    });
+    try {
+      return await global.client.prisma.raidSchedulingOption.create({
+        data: {
+          RaidId: raidId,
+          Timestamp: timestamp,
+          Option: nextOption,
+        },
+      });
+    } catch (error: any) {
+      // P2002 = unique constraint violation on (RaidId, Timestamp). This closes
+      // the race the findFirst check above can't: two concurrent executions
+      // (e.g. a replayed gateway interaction) both passing the check and racing
+      // to insert. The DB rejects the second; return the row that won.
+      if (error?.code === "P2002") {
+        log.info(
+          "Duplicate scheduling option rejected by DB for raid " +
+            raidId +
+            " at " +
+            timestamp.toISOString() +
+            "; returning existing"
+        );
+        return global.client.prisma.raidSchedulingOption.findFirst({
+          where: { RaidId: raidId, Timestamp: timestamp },
+        });
+      }
+      throw error;
+    }
   }
 
   static async SendSchedulingMessage(raidId: number) {

--- a/prisma/migrations/20260624000000_unique_raid_scheduling_option/migration.sql
+++ b/prisma/migrations/20260624000000_unique_raid_scheduling_option/migration.sql
@@ -1,0 +1,49 @@
+-- Enforce one scheduling option per (RaidId, Timestamp) so a double-fired
+-- interaction (gateway event replay on reconnect, or overlapping bot instances
+-- during a deploy) can no longer create duplicate "No votes" time slots.
+--
+-- The live DB may already contain duplicates created before this guard existed,
+-- which would make the CREATE UNIQUE INDEX below fail. So we de-duplicate first,
+-- keeping the lowest ID per (RaidId, Timestamp) and preserving any votes.
+--
+-- NULL RaidId/Timestamp rows are intentionally left untouched: MySQL allows
+-- multiple NULLs in a unique index, so they neither conflict nor need merging.
+
+-- 1. Move votes from duplicate options onto the surviving (lowest-ID) option.
+--    INSERT IGNORE skips members who already voted on the survivor (the
+--    RaidAvailability PK is (SchedulingOptionId, MemberId)), avoiding collisions.
+INSERT IGNORE INTO `RaidAvailability` (`SchedulingOptionId`, `MemberId`)
+SELECT `keep`.`keepId`, `ra`.`MemberId`
+FROM `RaidAvailability` `ra`
+JOIN `RaidSchedulingOption` `dup` ON `ra`.`SchedulingOptionId` = `dup`.`ID`
+JOIN (
+  SELECT `RaidId`, `Timestamp`, MIN(`ID`) AS `keepId`
+  FROM `RaidSchedulingOption`
+  WHERE `RaidId` IS NOT NULL AND `Timestamp` IS NOT NULL
+  GROUP BY `RaidId`, `Timestamp`
+) `keep` ON `keep`.`RaidId` = `dup`.`RaidId` AND `keep`.`Timestamp` = `dup`.`Timestamp`
+WHERE `dup`.`ID` <> `keep`.`keepId`;
+
+-- 2. Remove the now-migrated votes that still point at duplicate options.
+DELETE `ra` FROM `RaidAvailability` `ra`
+JOIN `RaidSchedulingOption` `dup` ON `ra`.`SchedulingOptionId` = `dup`.`ID`
+JOIN (
+  SELECT `RaidId`, `Timestamp`, MIN(`ID`) AS `keepId`
+  FROM `RaidSchedulingOption`
+  WHERE `RaidId` IS NOT NULL AND `Timestamp` IS NOT NULL
+  GROUP BY `RaidId`, `Timestamp`
+) `keep` ON `keep`.`RaidId` = `dup`.`RaidId` AND `keep`.`Timestamp` = `dup`.`Timestamp`
+WHERE `dup`.`ID` <> `keep`.`keepId`;
+
+-- 3. Delete the duplicate scheduling options themselves.
+DELETE `dup` FROM `RaidSchedulingOption` `dup`
+JOIN (
+  SELECT `RaidId`, `Timestamp`, MIN(`ID`) AS `keepId`
+  FROM `RaidSchedulingOption`
+  WHERE `RaidId` IS NOT NULL AND `Timestamp` IS NOT NULL
+  GROUP BY `RaidId`, `Timestamp`
+) `keep` ON `keep`.`RaidId` = `dup`.`RaidId` AND `keep`.`Timestamp` = `dup`.`Timestamp`
+WHERE `dup`.`ID` <> `keep`.`keepId`;
+
+-- 4. Enforce uniqueness going forward.
+CREATE UNIQUE INDEX `RaidSchedulingOption_RaidId_Timestamp_key` ON `RaidSchedulingOption`(`RaidId`, `Timestamp`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -247,6 +247,7 @@ model RaidSchedulingOption {
   RaidAvailability RaidAvailability[]
   Raids            Raids?             @relation(fields: [RaidId], references: [ID], onDelete: NoAction, onUpdate: NoAction, map: "RaidSchedulingOption_Raids_ID_fk")
 
+  @@unique([RaidId, Timestamp], map: "RaidSchedulingOption_RaidId_Timestamp_key")
   @@index([RaidId], map: "RaidSchedulingOption_Raids_ID_fk")
 }
 


### PR DESCRIPTION
## Summary
Adds database-level and application-level guards to prevent duplicate raid scheduling options at the same timestamp. This fixes a race condition where concurrent requests (e.g., gateway event replays, overlapping bot instances during deploy, or user double-clicks) could create multiple identical "No votes" time slots for the same raid.

## Changes

- **RaidScheduler.ts**: Enhanced `AddSingleSchedulingOptionToRaid()` with:
  - Pre-check using `findFirst()` to catch duplicates before creation
  - Try-catch around the `create()` call to handle P2002 unique constraint violations from concurrent inserts
  - Graceful fallback: returns the existing option instead of throwing on race-condition collisions
  - Detailed logging for both duplicate detection paths

- **Prisma schema**: Added unique constraint on `(RaidId, Timestamp)` to the `RaidSchedulingOption` model, enforced at the database level

- **Migration**: Created `20260624000000_unique_raid_scheduling_option/migration.sql` that:
  - De-duplicates existing rows by keeping the lowest ID per `(RaidId, Timestamp)` pair
  - Migrates votes from duplicate options to the surviving option using `INSERT IGNORE`
  - Cleans up orphaned votes and duplicate rows
  - Creates the unique index to prevent future duplicates

## Implementation Details
The solution uses a two-layer defense:
1. **Application layer**: `findFirst()` check catches most duplicates before DB round-trip
2. **Database layer**: Unique constraint + P2002 error handling closes the race window between the check and insert, ensuring idempotent behavior even under concurrent load

NULL `RaidId`/`Timestamp` rows are intentionally preserved during migration since MySQL allows multiple NULLs in unique indexes.

https://claude.ai/code/session_012VDHydU2t2UzHmivBw2f23