### PR TITLE
Simplify raid vote select menu labels to letter-only format

### DIFF
--- a/modules/RaidEmbeds.ts
+++ b/modules/RaidEmbeds.ts
@@ -142,23 +142,18 @@ export abstract class RaidEmbeds {
   ) {
     const select = new StringSelectMenuBuilder()
       .setCustomId(`raidVote_${raidId}`)
-      .setPlaceholder("Select all time slots you are available for")
+      .setPlaceholder("Select the time slots (A, B, C…) you are available for")
       .setMinValues(0)
       .setMaxValues(Math.min(options.length, 25));
 
     options.forEach((option) => {
-      const unixTime = Math.floor(option.Timestamp.getTime() / 1000);
-      // We use a formatted string for the label because select menus don't support discord timestamps in labels
-      const dateString = option.Timestamp.toLocaleDateString("en-GB", {
-        weekday: "short",
-        day: "numeric",
-        month: "short",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-
+      // Select menus don't support Discord timestamps in labels, so any time
+      // we render here would be fixed to the server's timezone and conflict
+      // with the per-viewer localized times shown in the message above.
+      // We therefore label options by their letter only and let users read
+      // the localized times from the message.
       select.addOptions({
-        label: `${option.Option}: ${dateString}`,
+        label: option.Option,
         value: option.ID.toString(),
         default: userSelectedOptions.includes(option.ID),
       });


### PR DESCRIPTION
## Summary
Refactored the raid vote select menu to display only letter labels (A, B, C…) instead of formatted datetime strings. This resolves a timezone localization conflict where select menu labels were fixed to the server's timezone, while the message above showed per-viewer localized times.

## Changes
- **Placeholder text**: Updated to clarify that options are labeled by letter ("Select the time slots (A, B, C…) you are available for")
- **Label generation**: Removed the `dateString` formatting logic that converted timestamps to locale-specific datetime strings
- **Option labels**: Simplified from `"${option.Option}: ${dateString}"` to just `option.Option` (the letter designation)
- **Documentation**: Added inline comment explaining why timestamps are not included in select menu labels and how users should read localized times from the message above

## Implementation Details
The change eliminates the mismatch between:
- Select menu labels (server timezone) 
- Message embed times (per-viewer localized via Discord timestamps)

Users now reference the letter-labeled options in the select menu and read the actual times from the localized timestamps in the message above, ensuring consistency across all viewers regardless of their timezone.

https://claude.ai/code/session_01VS1dM2YRNjJdTdBhgrTsjC