### PR TITLE
Fix raid scheduling to respect slot expiration times

### DIFF
--- a/modules/RaidEmbeds.ts
+++ b/modules/RaidEmbeds.ts
@@ -39,9 +39,13 @@ export abstract class RaidEmbeds {
       RaidSchedulingOption: RaidSchedulingOption[];
     }
   ) {
-    let finishTime = new Date(raid.RaidSchedulingOption[0].Timestamp.getTime());
-    finishTime.setDate(finishTime.getDate() - 1);
-    finishTime.setHours(0, 0, 0, 0);
+    // Scheduling stays open until every proposed slot has passed — the raid is
+    // only cancelled once no upcoming slot remains (see RaidScheduler.scheduleRaid),
+    // so the close time is the latest option, not the earliest.
+    const latestTimestamp = Math.max(
+      ...raid.RaidSchedulingOption.map((o) => o.Timestamp.getTime())
+    );
+    let finishTime = new Date(latestTimestamp);
 
     let participants = "";
     raid.RaidAttendees.forEach((attendee) => {

--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -306,8 +306,12 @@ export abstract class RaidScheduler {
     log.info("Collecting raid " + raid.ID);
     let votes = await this.CollectSchedulingVotes(raid);
     let consensusVotes = new Map<RaidSchedulingOption, string[]>();
+    const now = new Date().getTime();
     votes.forEach((value, key) => {
-      if (value.length >= raid.MinPlayers) {
+      // Only schedule a slot that is still in the future — a slot whose time has
+      // already passed can't be played even if it reached enough votes. (Slots
+      // can outlive their time now that raids stay open until every slot passes.)
+      if (value.length >= raid.MinPlayers && key.Timestamp.getTime() > now) {
         consensusVotes.set(key, value);
       }
     });

--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -330,10 +330,17 @@ export abstract class RaidScheduler {
       }
     } else {
       log.info("No consensus reached for raid " + raid.ID);
-      let finishingTime = new Date(raid.RaidSchedulingOption[0].Timestamp);
-      finishingTime.setDate(finishingTime.getDate() - 1);
-      finishingTime.setHours(0, 0, 0, 0);
-      if (new Date().getTime() > finishingTime.getTime()) {
+      // Only cancel once every proposed timeslot is in the past. As long as any
+      // slot (seeded or custom-suggested) is still upcoming, keep the raid open
+      // so people can still reach consensus on it — otherwise suggesting a later
+      // time would be pointless if the original earliest-slot deadline had passed.
+      const latestTimestamp = Math.max(
+        ...raid.RaidSchedulingOption.map((o) => o.Timestamp.getTime())
+      );
+      if (
+        raid.RaidSchedulingOption.length > 0 &&
+        new Date().getTime() > latestTimestamp
+      ) {
         log.info("Cancelling raid " + raid.ID);
         await this.cancelRaid(raid);
       }


### PR DESCRIPTION
## Summary
Updates raid scheduling logic to prevent scheduling slots that have already passed in time, and to keep raids open for voting until all proposed timeslots have expired (rather than closing based on the earliest slot).

## Key Changes

- **RaidScheduler.ts — `scheduleRaid()` method:**
  - Added timestamp check when collecting consensus votes: only slots with future timestamps (`key.Timestamp.getTime() > now`) are considered for scheduling
  - This prevents scheduling a raid to a timeslot that has already passed, even if it reached the minimum vote threshold

- **RaidScheduler.ts — raid cancellation logic:**
  - Changed cancellation condition from checking if the earliest slot's deadline has passed to checking if the *latest* slot has passed
  - Raids now stay open for voting as long as any proposed timeslot (seeded or custom-suggested) is still in the future
  - This allows players to suggest later times and reach consensus without the raid being cancelled prematurely

- **RaidEmbeds.ts — `buildRaidEmbed()` method:**
  - Updated the raid scheduling close time calculation to use the latest timeslot instead of the earliest
  - Aligns the embed display with the actual scheduling behavior

## Implementation Details

The changes use `Math.max(...raid.RaidSchedulingOption.map((o) => o.Timestamp.getTime()))` to find the latest proposed slot, ensuring the raid remains open until all options have expired. This maintains the intent that raids stay open until every slot passes, allowing players to continue voting on later-proposed times.

https://claude.ai/code/session_01VS1dM2YRNjJdTdBhgrTsjC