### PR TITLE
Improve raid scheduling: auto-enlist creator, auto-vote suggester, Discord events, fewer default slots

### DIFF
--- a/interactionHandlers/commands/createRaid.ts
+++ b/interactionHandlers/commands/createRaid.ts
@@ -1,6 +1,8 @@
 import { SlashCommandBuilder } from "discord.js";
 import { ChannelUpdates } from "../../islander/ChannelUpdates";
 import { IHandler } from "../../interfaces/IHandler";
+import { RaidModule } from "../../modules/RaidModule";
+import { RaidScheduler } from "../../modules/RaidScheduler";
 import { createLogger } from "../../utils/logger";
 
 const log = createLogger("CreateRaid");
@@ -29,13 +31,25 @@ export default class CreateRaidCommand implements IHandler {
     const title = interaction.options.getString("title");
     const minPlayers = interaction.options.getInteger("minplayers");
 
-    await global.client.prisma.raids.create({
+    const raid = await global.client.prisma.raids.create({
       data: {
         Title: title,
         MinPlayers: minPlayers,
         Creator: interaction.user.id,
       },
     });
+
+    // Auto-enlist the creator as the first participant. Use the silent
+    // low-level helper (not AddUserToRaid) to avoid a redundant "has joined the
+    // raid" message on top of the "New raid created" update below, then run the
+    // scheduling check so a minplayers:1 raid still advances immediately.
+    try {
+      await RaidModule.AddAttendeeToRaid(raid.ID, interaction.user.id);
+      await RaidScheduler.SchedulingCreationCheck(raid.ID);
+    } catch (err) {
+      log.error("Failed to auto-enlist raid creator:", err);
+    }
+
     ChannelUpdates.MessageWithRaid("New raid created: " + title).catch((err) =>
       log.error("Failed to send raid channel update:", err)
     );

--- a/interactionHandlers/modals/raidCustomTimeSubmit.ts
+++ b/interactionHandlers/modals/raidCustomTimeSubmit.ts
@@ -51,7 +51,30 @@ export default class RaidCustomTimeSubmitHandler implements IHandler {
     }
 
     try {
-      await RaidScheduler.AddSingleSchedulingOptionToRaid(raidId, parsed.toDate());
+      const option = await RaidScheduler.AddSingleSchedulingOptionToRaid(
+        raidId,
+        parsed.toDate()
+      );
+
+      // Auto-accept the slot for whoever suggested it — they clearly want this
+      // time, so count them in without making them vote for their own option.
+      // upsert keeps it idempotent if the option already existed and they'd
+      // already voted (composite PK SchedulingOptionId + MemberId).
+      if (option) {
+        await global.client.prisma.raidAvailability.upsert({
+          where: {
+            SchedulingOptionId_MemberId: {
+              SchedulingOptionId: option.ID,
+              MemberId: interaction.user.id,
+            },
+          },
+          create: {
+            SchedulingOptionId: option.ID,
+            MemberId: interaction.user.id,
+          },
+          update: {},
+        });
+      }
 
       // Re-send the scheduling DM to every participant so the new option shows
       // up in their voting menu — Discord won't update already-sent select menus.
@@ -62,7 +85,11 @@ export default class RaidCustomTimeSubmitHandler implements IHandler {
       });
 
       // Notify in LFG
-      const raid = await global.client.prisma.raids.findUnique({
+      const raid = await global.client.prisma.raids.findFirst({
+        include: {
+          RaidAttendees: true,
+          RaidSchedulingOption: true,
+        },
         where: { ID: raidId },
       });
 
@@ -74,6 +101,13 @@ export default class RaidCustomTimeSubmitHandler implements IHandler {
           .catch((e) =>
             log.error("Failed to send custom time suggestion to lfg:", e)
           );
+
+        // The suggester's auto-vote may have completed consensus on this slot —
+        // re-check immediately so it can be scheduled without waiting for the
+        // next poll (mirrors the raidVote select handler).
+        if (raid.Status === 2) {
+          await RaidScheduler.scheduleRaid(raid as any);
+        }
       }
     } catch (error) {
       log.error("Error adding custom scheduling option:", error);

--- a/modules/RaidScheduler.ts
+++ b/modules/RaidScheduler.ts
@@ -1,4 +1,10 @@
-import { EmbedBuilder, MessageCreateOptions, User } from "discord.js";
+import {
+  EmbedBuilder,
+  GuildScheduledEventEntityType,
+  GuildScheduledEventPrivacyLevel,
+  MessageCreateOptions,
+  User,
+} from "discord.js";
 import { RaidAttendees, Raids, RaidSchedulingOption } from "@prisma/client";
 import { RaidEmbeds } from "./RaidEmbeds";
 import { createLogger } from "../utils/logger";
@@ -74,17 +80,15 @@ export abstract class RaidScheduler {
     let thursday = new Date(tuesday.getTime());
     thursday.setDate(tuesday.getDate() + 2);
 
+    // Seed only a minimal set of default slots — one 19:00 (prime-time) option
+    // per day. The community prefers suggesting their own times, so keeping the
+    // defaults light avoids cluttering the voting menu. Custom suggestions
+    // continue lettering from "C" onward via AddSingleSchedulingOptionToRaid.
     return global.client.prisma.raidSchedulingOption.createMany({
       data: [
-        { RaidId: raidId, Timestamp: new Date(tuesday.setHours(17, 0, 0, 0)), Option: "A" },
-        { RaidId: raidId, Timestamp: new Date(tuesday.setHours(19, 0, 0, 0)), Option: "B" },
-        { RaidId: raidId, Timestamp: new Date(tuesday.setHours(21, 0, 0, 0)), Option: "C" },
-        { RaidId: raidId, Timestamp: new Date(wednesday.setHours(17, 0, 0, 0)), Option: "D" },
-        { RaidId: raidId, Timestamp: new Date(wednesday.setHours(19, 0, 0, 0)), Option: "E" },
-        { RaidId: raidId, Timestamp: new Date(wednesday.setHours(21, 0, 0, 0)), Option: "F" },
-        { RaidId: raidId, Timestamp: new Date(thursday.setHours(17, 0, 0, 0)), Option: "G" },
-        { RaidId: raidId, Timestamp: new Date(thursday.setHours(19, 0, 0, 0)), Option: "H" },
-        { RaidId: raidId, Timestamp: new Date(thursday.setHours(21, 0, 0, 0)), Option: "I" },
+        { RaidId: raidId, Timestamp: new Date(tuesday.setHours(19, 0, 0, 0)), Option: "A" },
+        { RaidId: raidId, Timestamp: new Date(wednesday.setHours(19, 0, 0, 0)), Option: "B" },
+        { RaidId: raidId, Timestamp: new Date(thursday.setHours(19, 0, 0, 0)), Option: "C" },
       ],
     });
   }
@@ -391,6 +395,30 @@ export abstract class RaidScheduler {
       where: { ID: raid.ID },
       data: { Status: 3 },
     });
+
+    // Surface the confirmed raid on the server's Events tab. External events
+    // require both an end time and a location; we run 2h from the chosen start
+    // and point at the LFG channel. Non-fatal: a failure here must not block the
+    // confirmation DMs/announcement below.
+    try {
+      const guild = await global.client.guilds.fetch(process.env.GUILD_ID!);
+      const start = key.Timestamp;
+      const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+      await guild.scheduledEvents.create({
+        name: raid.Title,
+        scheduledStartTime: start,
+        scheduledEndTime: end,
+        privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+        entityType: GuildScheduledEventEntityType.External,
+        entityMetadata: { location: `#${global.client.lfg?.name ?? "lfg"}` },
+        description: `Raid scheduled via FlamingPalm. Participants: ${raid.RaidAttendees.length}`,
+      });
+    } catch (err) {
+      log.error(
+        "Failed to create Discord scheduled event for raid " + raid.ID + ":",
+        err
+      );
+    }
 
     let embed = new EmbedBuilder()
       .setTitle("Raid: " + raid.Title)


### PR DESCRIPTION
- Auto-enlist the raid creator as the first participant on /create-raid
- Auto-accept a suggested timeslot for whoever suggested it, and re-check
  consensus immediately so a suggestion can schedule without waiting
- Create a Discord guild scheduled event when a raid is confirmed
  (External, 2h, location = LFG channel); non-fatal on failure
- Reduce default scheduling slots from 9 to 3 (one 19:00 slot per day)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QCmkqaYYB6f4yXv6FSVESC